### PR TITLE
Feature/reset workspace

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,6 +30,10 @@ This repository is a monorepo that houses multiple packages. It uses Yarn Worksp
  ```bash
     ./reset-aspel-workspace.sh
  ````
+or
+   ```shell
+   npm run reset
+   ```
 ***
 
 # Manually

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -25,6 +25,14 @@ This repository is a monorepo that houses multiple packages. It uses Yarn Worksp
 - How workspaces works? [Link Here](https://collaboration.homeoffice.gov.uk/display/ASPEL/Setup+local+Environment+ASPeL)
 ### Installation
 
+***
+# Quick start
+ ```bash
+    ./reset-aspel-workspace.sh
+ ````
+***
+
+# Manually
 1. Clone the repository:
 
    ```sh

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   ],
   "version": "1.0.0",
   "scripts": {
-    "echo": "echo 'workspace is in action'",
-    "dev": "echo 'sorry: workspace not ready to run dev servers.'",
-    "build": "yarn workspaces run build"
+    "reset": "./reset-aspel-workspace.sh",
+    "echo": "echo 'workspace is in action'"
   },
   "devDependencies": {},
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "reset": "./reset-aspel-workspace.sh",
     "echo": "echo 'workspace is in action'"

--- a/reset-aspel-worspace.sh
+++ b/reset-aspel-worspace.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Step 1: Reset and clean all submodules
+for dir in packages/*; do
+  if [ -d "$dir/.git" ]; then
+    echo "-----------------------------------------------"
+    echo " 🚧  Resetting and cleaning $dir... Please wait!"
+    echo "-----------------------------------------------"
+
+    # Navigate to the submodule directory
+    cd "$dir"
+
+    # Revert any changes (reset to HEAD)
+    git reset --hard
+
+    # Remove untracked files (including node_modules and package-lock.json)
+    git clean -fdx
+
+    # Go back to the root directory
+    cd - > /dev/null
+  fi
+done
+
+echo "==============================================="
+echo "   ✅  All submodules have been reset and cleaned!  "
+echo "==============================================="
+
+# Step 2: Checkout the main or master branch and pull the latest changes
+echo "-----------------------------------------------"
+echo " 🔄  Checking out main/master and pulling latest changes for all submodules..."
+echo "-----------------------------------------------"
+
+git submodule foreach 'git checkout main || git checkout master'
+git submodule foreach git pull
+
+echo "==============================================="
+echo "   ✅  All submodules have been updated to the latest version!  "
+echo "==============================================="
+
+# Step 3: Remove node_modules and package-lock.json across all submodules
+find packages -type d -name "node_modules" -exec rm -rf {} +
+find packages -type f -name "package-lock.json" -exec rm -f {} +
+
+echo "Cleanup of node_modules and package-lock.json completed."
+
+# Step 4: Reinstall dependencies using Yarn
+yarn install
+
+echo "==============================================="
+echo "   ✅ Yarn has installed dependencies - ready to run the servers..."
+echo "==============================================="


### PR DESCRIPTION
A small utility script was added.
1 - Reset git in submodules.
2- Remove `nodule_modules` & `package-lock`. We may have added them as a part of some dev work and our pipeline expects package-lock to be committed. However, when we want to continue working on a new feature the workspace should be reset and use common node_modules where possible. 
3- checkout master and pull the latest
4- install dependencies. 


I felt the need for this - anytime I merged my changes, I would need to reset for reliability and to utilise workspace features. 