### PR TITLE
Fix ASL Attachments Sharp Dependency

### DIFF
--- a/packages/asl-attachments/.npmrc
+++ b/packages/asl-attachments/.npmrc
@@ -1,9 +1,0 @@
-registry=https://registry.npmjs.org/
-
-
-@ukhomeoffice:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}
-
-@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_authToken=${ART_AUTH_TOKEN}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:always-auth=true

--- a/packages/asl-attachments/Dockerfile
+++ b/packages/asl-attachments/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=secret,id=token \
     ART_AUTH_TOKEN=`cat /run/secrets/token` \
     GITHUB_AUTH_TOKEN=`cat /run/secrets/github_token` \
     npm update npm \
-    npm ci --omit=optional --omit=dev --ignore-scripts --loglevel=verbose
+    npm ci --omit=dev --ignore-scripts --loglevel=verbose
 
 FROM quay.io/ukhomeofficedigital/asl-base:v18
 


### PR DESCRIPTION
A subtle discrepancy in the original build logic for `asl-attachments` vs the new workspace set up was preventing the necessary dependencies being installed for the `sharp` package. Optional dependencies must be enabled for the docker build install for `asl-attachments` as these provide the the platform tools (stored in `node_modules/@img`) to successfully run `sharp`.

The reason the original package worked was because `node_modules` were leaking in from the builder environment as there was no `.dockerignore` file present. So although the install command was:

`npm ci --production --no-optional`

The copy command on the next line:

`COPY . /app`

Copied over all the rest of the dependencies installed by the CI runner.