### PR TITLE
Revert asl-components to 13.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -178,35 +178,6 @@
         "slate-react": "^0.22.4"
       }
     },
-    "node_modules/@asl/projects/node_modules/@ukhomeoffice/asl-components": {
-      "version": "13.9.1",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.1/02150810d650f014a69956292dd76eea58feb8d4",
-      "integrity": "sha512-8yoEun4qgQdgjaUlcSbEEBVprdQeqtPV1KSkHF3iqopB7XFwqVDW6g7VaG45kXWMVQVIhDOAa79u5HUOUKaEbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ukhomeoffice/asl-constants": "^2.2.0",
-        "@ukhomeoffice/asl-dictionary": "^2.1.0",
-        "@ukhomeoffice/react-components": "^1.3.3",
-        "@x-govuk/govuk-prototype-components": "^3.0.9",
-        "accessible-autocomplete": "^2.0.3",
-        "classnames": "^2.2.6",
-        "date-fns": "^3.6.0",
-        "diff": "^4.0.1",
-        "govuk-frontend": "^5.8.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.4",
-        "mustache": "^3.0.1",
-        "qs": "^6.6.1",
-        "react": "^16.9.0",
-        "react-markdown": "^6.0.2",
-        "react-redux": "^7.1.0",
-        "redux": "^4.0.1",
-        "remark-breaks": "^2.0.2",
-        "shasum": "^1.0.2",
-        "url": "^0.11.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "node_modules/@asl/projects/node_modules/@ukhomeoffice/asl-slate-edit-list": {
       "version": "0.0.8",
       "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-slate-edit-list/0.0.8/63cb78074ecb40b82ec4e1a45421009a999ae0f7",
@@ -218,15 +189,6 @@
         "slate-react": "^0.22.4"
       }
     },
-    "node_modules/@asl/projects/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/@asl/projects/node_modules/immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -234,18 +196,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@asl/projects/node_modules/mustache": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
-      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      },
-      "engines": {
-        "npm": ">=1.4.0"
       }
     },
     "node_modules/@asl/schema": {
@@ -469,56 +419,6 @@
       },
       "peerDependencies": {
         "webpack": "^5.69.1"
-      }
-    },
-    "node_modules/@asl/service/node_modules/@ukhomeoffice/asl-components": {
-      "version": "13.9.1",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.1/02150810d650f014a69956292dd76eea58feb8d4",
-      "integrity": "sha512-8yoEun4qgQdgjaUlcSbEEBVprdQeqtPV1KSkHF3iqopB7XFwqVDW6g7VaG45kXWMVQVIhDOAa79u5HUOUKaEbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ukhomeoffice/asl-constants": "^2.2.0",
-        "@ukhomeoffice/asl-dictionary": "^2.1.0",
-        "@ukhomeoffice/react-components": "^1.3.3",
-        "@x-govuk/govuk-prototype-components": "^3.0.9",
-        "accessible-autocomplete": "^2.0.3",
-        "classnames": "^2.2.6",
-        "date-fns": "^3.6.0",
-        "diff": "^4.0.1",
-        "govuk-frontend": "^5.8.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.4",
-        "mustache": "^3.0.1",
-        "qs": "^6.6.1",
-        "react": "^16.9.0",
-        "react-markdown": "^6.0.2",
-        "react-redux": "^7.1.0",
-        "redux": "^4.0.1",
-        "remark-breaks": "^2.0.2",
-        "shasum": "^1.0.2",
-        "url": "^0.11.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@asl/service/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
-      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      },
-      "engines": {
-        "npm": ">=1.4.0"
-      }
-    },
-    "node_modules/@asl/service/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/@asl/service/node_modules/hot-shots": {
@@ -3937,14 +3837,14 @@
       }
     },
     "node_modules/@ukhomeoffice/asl-components": {
-      "version": "13.9.3",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.3/8a470fa16860d3377a81da13a51c68eb0d85cd6a",
-      "integrity": "sha512-1fMPH6u+wGNjvzOW/2VJ3gqkEDBpgyOd/ISG7F5KFiRnpMfsUdOm5dAgY85mu7TUAFifan1iIQJUaldjzEAMPg==",
+      "version": "13.9.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.1/02150810d650f014a69956292dd76eea58feb8d4",
+      "integrity": "sha512-8yoEun4qgQdgjaUlcSbEEBVprdQeqtPV1KSkHF3iqopB7XFwqVDW6g7VaG45kXWMVQVIhDOAa79u5HUOUKaEbg==",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "^2.2.0",
         "@ukhomeoffice/asl-dictionary": "^2.1.0",
-        "@ukhomeoffice/react-components": "^1.4.2",
+        "@ukhomeoffice/react-components": "^1.3.3",
         "@x-govuk/govuk-prototype-components": "^3.0.9",
         "accessible-autocomplete": "^2.0.3",
         "classnames": "^2.2.6",
@@ -19648,7 +19548,7 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-react": "^7.22.15",
-        "@ukhomeoffice/asl-components": "^13.7.0",
+        "@ukhomeoffice/asl-components": "13.9.1",
         "@ukhomeoffice/asl-constants": "^2.2.0",
         "@ukhomeoffice/frontend-toolkit": "^3.0.0",
         "@ukhomeoffice/react-components": "^1.3.3",
@@ -21033,7 +20933,7 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-react": "^7.22.15",
-        "@ukhomeoffice/asl-components": "^13.7.0",
+        "@ukhomeoffice/asl-components": "13.9.1",
         "@ukhomeoffice/asl-constants": "^2.2.0",
         "@ukhomeoffice/react-components": "^1.3.3",
         "accessible-autocomplete": "^2.0.3",

--- a/packages/asl-internal-ui/package.json
+++ b/packages/asl-internal-ui/package.json
@@ -38,7 +38,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
-    "@ukhomeoffice/asl-components": "^13.7.0",
+    "@ukhomeoffice/asl-components": "13.9.1",
     "@ukhomeoffice/asl-constants": "^2.2.0",
     "@ukhomeoffice/react-components": "^1.3.3",
     "accessible-autocomplete": "^2.0.3",

--- a/packages/asl/package.json
+++ b/packages/asl/package.json
@@ -36,7 +36,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
-    "@ukhomeoffice/asl-components": "^13.7.0",
+    "@ukhomeoffice/asl-components": "13.9.1",
     "@ukhomeoffice/asl-constants": "^2.2.0",
     "@ukhomeoffice/frontend-toolkit": "^3.0.0",
     "@ukhomeoffice/react-components": "^1.3.3",


### PR DESCRIPTION
A change to the `fieldset` component in newer versions of `asl-components` is causing breakages in `asl-internal-ui`. The issue is [this line here](https://github.com/UKHomeOffice/asl-components/blob/main/src/fieldset/index.jsx#L216) where `normalisedOptions` is null/undefined and therefore the `find` method is unavailable.

You can see the result of this error in this test screenshot:

[tests/actual/ROPS-can_add_additional_purposes_which_require_extra_questions_to_be_completed-full-chrome-1260x800-dpr-1.png](https://github.com/UKHomeOffice/asl-deployments/commit/32f5b764b5cf8bbbdb7a266d27a7476d765aa583#diff-575205ffaf55e634b037e80883405de34530a0f17347354907741284d9f2f41e)

I have pinned the workspace to version `13.9.1` as a workaround while this is fixed. It will need to be fixed or reverted before we merge `asl-components`.

Unfortunately, although npm workspaces allows local package dependency declaration which should in theory allow us to just set this pin for the internal ui, webpack looks for node modules in the root folder when building so it has to be the common version for the workspace. This also reverts the current usage in `asl`. Once all submodules are merged in the common version will be explicit anyway since all packages must use the same code.