### PR TITLE
Add deployset scripts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,51 @@
+---
+
 kind: pipeline
-name: asl-emailer
+name: deployset
+type: kubernetes
+
+steps:
+  - name: install
+    image: node:18
+    commands:
+      - npm ci --workspaces=false
+  - name: deployset
+    image: node:18
+    environment:
+      DRONE_SERVER: ${DRONE_SYSTEM_PROTO}://${DRONE_SYSTEM_HOST}
+      DRONE_TOKEN:
+        from_secret: drone_token
+      DRONE_REPO_OWNER: ${DRONE_REPO_OWNER}
+      DRONE_REPO_NAME: ${DRONE_REPO_NAME}
+      DRONE_BUILD_NUMBER: ${DRONE_BUILD_NUMBER}
+      BUILD_STAGES: asl asl-attachments asl-data-exports asl-emailer asl-internal-api asl-internal-ui asl-metrics asl-notifications asl-permissions asl-public-api asl-resolver asl-search asl-workflow
+      SKIP_STATUS: 78
+    commands:
+      - node ./scripts/deployset.js $BUILD_STAGES > .deploy-set
+  - name: manifest
+    image: node:18
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_access_token
+      GITHUB_REPO_OWNER: ukhomeoffice
+      GITHUB_REPO_NAME: asl-deployments
+      GITHUB_MANIFEST_PATH: versions.yml
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+    commands:
+      # Drone inexplicably creates yaml parse errors when reassigning this through the `envionment` block
+      - export SOURCE_COMMIT_MESSAGE=$DRONE_COMMIT_MESSAGE
+      - node ./scripts/manifest.js $(cat .deploy-set)
+
+trigger:
+  event:
+    - push
+  branch:
+    - main
+
+---
+
+kind: pipeline
+name: asl
 type: kubernetes
 
 clone:
@@ -17,7 +63,7 @@ steps:
       SOURCE_COMMIT: "${DRONE_COMMIT}"
       BUILD_EVENT: "${DRONE_BUILD_EVENT}"
       SKIP_STATUS: 78
-      MODULES: packages/asl-emailer
+      MODULES: packages/asl
     commands:
       - git config advice.detachedHead false
       - git checkout $DRONE_COMMIT
@@ -33,7 +79,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm ci --workspace asl-emailer
+      - npm ci --workspace asl
   - name: test
     image: node:22.14.0
     environment:
@@ -42,7 +88,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm run test --workspace asl-emailer
+      - npm run test --workspace asl
   - name: audit
     image: node:22.14.0
     environment:
@@ -51,7 +97,16 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm audit --workspace=asl-emailer --audit-level=high --omit=dev
+      - npm audit --workspace=asl --audit-level=high --omit=dev
+  - name: compile
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run build --workspace asl --production
   - name: docker build
     image: docker:dind
     environment:
@@ -62,7 +117,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - docker build -f ./packages/asl-emailer/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-emailer .
+      - docker build -f ./packages/asl/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl .
   - name: scan-image
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
@@ -71,8 +126,8 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: asl-emailer
-      ALLOW_CVE_LIST_FILE: packages/asl-emailer/cve-exceptions.txt
+      IMAGE_NAME: asl
+      ALLOW_CVE_LIST_FILE: packages/asl/cve-exceptions.txt
       TIMEOUT: 10m
   - name: docker push
     image: docker:dind
@@ -86,25 +141,8 @@ steps:
         from_secret: quay_password
     commands:
       - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-emailer quay.io/ukhomeofficedigital/asl-emailer:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-emailer:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-emailer
-        --version $${DRONE_COMMIT_SHA}
+      - docker tag asl quay.io/ukhomeofficedigital/asl:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl:$${DRONE_COMMIT_SHA}
     when:
       event:
         - push
@@ -112,10 +150,15 @@ steps:
         - main
 
 services:
-- name: docker
-  image: docker:dind
-  environment:
-    DOCKER_TLS_CERTDIR: ""
+  - name: docker
+    image: docker:dind
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+
+trigger:
+  event:
+    - push
+    - pull_request
 
 ---
 
@@ -214,23 +257,6 @@ steps:
         - push
       branch:
         - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-attachments
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
 
 services:
 - name: docker
@@ -243,135 +269,10 @@ services:
   commands:
     - /run.sh server
 
----
-
-kind: pipeline
-name: asl-notifications
-type: kubernetes
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: node:22.14.0
-    commands:
-      - git clone $DRONE_REMOTE_URL .
-  - name: changeset
-    image: node:22.14.0
-    environment:
-      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
-      SOURCE_COMMIT: "${DRONE_COMMIT}"
-      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
-      SKIP_STATUS: 78
-      MODULES: packages/asl-notifications
-    commands:
-      - git config advice.detachedHead false
-      - git checkout $DRONE_COMMIT
-      - node ./ci/changeset.js --modules $MODULES
-      - git checkout $DRONE_TARGET_BRANCH
-      - git merge $DRONE_COMMIT
-      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
-  - name: install
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm ci --workspace asl-notifications
-  - name: test
-    image: node:22.14.0
-    environment:
-      DATABASE_NAME: asl-test
-      DATABASE_HOST: postgres
-      DATABASE_USERNAME: asl-test
-      DATABASE_PASSWORD: test-password
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run test --workspace asl-notifications
-  - name: audit
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm audit --workspace=asl-notifications --audit-level=high --omit=dev
-  - name: docker build
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      DOCKER_BUILDKIT: 1
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - docker build -f ./packages/asl-notifications/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-notifications .
-  - name: scan-image
-    pull: always
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
-    resources:
-      limits:
-        cpu: 1000
-        memory: 1024Mi
-    environment:
-      IMAGE_NAME: asl-notifications
-      ALLOW_CVE_LIST_FILE: packages/asl-notifications/cve-exceptions.txt
-      TIMEOUT: 10m
-  - name: docker push
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-      DOCKER_PASSWORD:
-        from_secret: quay_password
-    commands:
-      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-notifications quay.io/ukhomeofficedigital/asl-notifications:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-notifications:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-notifications
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-
-services:
-- name: docker
-  image: docker:dind
-  environment:
-    DOCKER_TLS_CERTDIR: ""
-- name: postgres
-  image: postgres
-  environment:
-    POSTGRES_USER: asl-test
-    POSTGRES_PASSWORD: test-password
+trigger:
+  event:
+    - push
+    - pull_request
 
 ---
 
@@ -474,23 +375,6 @@ steps:
         - push
       branch:
         - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-data-exports
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
 
 services:
   - name: docker
@@ -502,6 +386,362 @@ services:
     environment:
       POSTGRES_USER: asl-test
       POSTGRES_PASSWORD: test-password
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+
+kind: pipeline
+name: asl-emailer
+type: kubernetes
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: node:22.14.0
+    commands:
+      - git clone $DRONE_REMOTE_URL .
+  - name: changeset
+    image: node:22.14.0
+    environment:
+      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
+      SKIP_STATUS: 78
+      MODULES: packages/asl-emailer
+    commands:
+      - git config advice.detachedHead false
+      - git checkout $DRONE_COMMIT
+      - node ./ci/changeset.js --modules $MODULES
+      - git checkout $DRONE_TARGET_BRANCH
+      - git merge $DRONE_COMMIT
+      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
+  - name: install
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm ci --workspace asl-emailer
+  - name: test
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run test --workspace asl-emailer
+  - name: audit
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm audit --workspace=asl-emailer --audit-level=high --omit=dev
+  - name: docker build
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_BUILDKIT: 1
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - docker build -f ./packages/asl-emailer/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-emailer .
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: asl-emailer
+      ALLOW_CVE_LIST_FILE: packages/asl-emailer/cve-exceptions.txt
+      TIMEOUT: 10m
+  - name: docker push
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+      DOCKER_PASSWORD:
+        from_secret: quay_password
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl-emailer quay.io/ukhomeofficedigital/asl-emailer:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-emailer:$${DRONE_COMMIT_SHA}
+    when:
+      event:
+        - push
+      branch:
+        - main
+
+services:
+- name: docker
+  image: docker:dind
+  environment:
+    DOCKER_TLS_CERTDIR: ""
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+
+kind: pipeline
+name: asl-internal-api
+type: kubernetes
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: node:22.14.0
+    commands:
+      - git clone $DRONE_REMOTE_URL .
+  - name: changeset
+    image: node:22.14.0
+    environment:
+      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
+      SKIP_STATUS: 78
+      MODULES: packages/asl-internal-api
+    commands:
+      - git config advice.detachedHead false
+      - git checkout $DRONE_COMMIT
+      - node ./ci/changeset.js --modules $MODULES
+      - git checkout $DRONE_TARGET_BRANCH
+      - git merge $DRONE_COMMIT
+      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
+  - name: install
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm ci --workspace asl-internal-api
+  - name: wait postgres
+    image: postgres
+    environment:
+      PGPASSWORD: test-password
+    commands:
+      - until psql -U asl-test -d asl-test -h postgres -c "SELECT 1;" >/dev/null 2>&1; do sleep 1; done
+  - name: test
+    image: node:22.14.0
+    environment:
+      DATABASE_NAME: asl-test
+      DATABASE_HOST: postgres
+      DATABASE_USERNAME: asl-test
+      DATABASE_PASSWORD: test-password
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run test --workspace asl-internal-api
+  - name: audit
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm audit --workspace=asl-internal-api --audit-level=high --omit=dev
+  - name: docker build
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_BUILDKIT: 1
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - docker build -f ./packages/asl-internal-api/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-internal-api .
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: asl-internal-api
+      ALLOW_CVE_LIST_FILE: packages/asl-internal-api/cve-exceptions.txt
+      TIMEOUT: 10m
+  - name: docker push
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+      DOCKER_PASSWORD:
+        from_secret: quay_password
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl-internal-api quay.io/ukhomeofficedigital/asl-internal-api:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-internal-api:$${DRONE_COMMIT_SHA}
+    when:
+      event:
+        - push
+      branch:
+        - main
+
+services:
+- name: docker
+  image: docker:dind
+  environment:
+    DOCKER_TLS_CERTDIR: ""
+- name: postgres
+  image: postgres
+  environment:
+    POSTGRES_USER: asl-test
+    POSTGRES_PASSWORD: test-password
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+
+kind: pipeline
+name: asl-internal-ui
+type: kubernetes
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: node:22.14.0
+    commands:
+      - git clone $DRONE_REMOTE_URL .
+  - name: changeset
+    image: node:22.14.0
+    environment:
+      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
+      SKIP_STATUS: 78
+      MODULES: packages/asl-internal-ui
+    commands:
+      - git config advice.detachedHead false
+      - git checkout $DRONE_COMMIT
+      - node ./ci/changeset.js --modules $MODULES
+      - git checkout $DRONE_TARGET_BRANCH
+      - git merge $DRONE_COMMIT
+      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
+  - name: install
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm ci --workspace asl-internal-ui
+  - name: test
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run test --workspace asl-internal-ui
+  - name: audit
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm audit --workspace=asl-internal-ui --audit-level=high --omit=dev
+  - name: compile
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run build --workspace asl-internal-ui --production
+  - name: docker build
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_BUILDKIT: 1
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - docker build -f ./packages/asl-internal-ui/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-internal-ui .
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: asl-internal-ui
+      ALLOW_CVE_LIST_FILE: packages/asl-internal-ui/cve-exceptions.txt
+      TIMEOUT: 10m
+  - name: docker push
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+      DOCKER_PASSWORD:
+        from_secret: quay_password
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl-internal-ui quay.io/ukhomeofficedigital/asl-internal-ui:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-internal-ui:$${DRONE_COMMIT_SHA}
+    when:
+      event:
+        - push
+      branch:
+        - main
+
+services:
+- name: docker
+  image: docker:dind
+  environment:
+    DOCKER_TLS_CERTDIR: ""
+
+trigger:
+  event:
+    - push
+    - pull_request
 
 ---
 
@@ -617,23 +857,6 @@ steps:
         - push
       branch:
         - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-metrics
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
 
 services:
 - name: docker
@@ -646,10 +869,15 @@ services:
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: test-password
 
+trigger:
+  event:
+    - push
+    - pull_request
+
 ---
 
 kind: pipeline
-name: asl-search
+name: asl-notifications
 type: kubernetes
 
 clone:
@@ -667,7 +895,7 @@ steps:
       SOURCE_COMMIT: "${DRONE_COMMIT}"
       BUILD_EVENT: "${DRONE_BUILD_EVENT}"
       SKIP_STATUS: 78
-      MODULES: packages/asl-search
+      MODULES: packages/asl-notifications
     commands:
       - git config advice.detachedHead false
       - git checkout $DRONE_COMMIT
@@ -683,16 +911,20 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm ci --workspace asl-search
+      - npm ci --workspace asl-notifications
   - name: test
     image: node:22.14.0
     environment:
+      DATABASE_NAME: asl-test
+      DATABASE_HOST: postgres
+      DATABASE_USERNAME: asl-test
+      DATABASE_PASSWORD: test-password
       ART_AUTH_TOKEN:
         from_secret: art_auth_token
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm run test --workspace asl-search
+      - npm run test --workspace asl-notifications
   - name: audit
     image: node:22.14.0
     environment:
@@ -701,7 +933,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm audit --workspace=asl-search --audit-level=high --omit=dev
+      - npm audit --workspace=asl-notifications --audit-level=high --omit=dev
   - name: docker build
     image: docker:dind
     environment:
@@ -712,7 +944,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - docker build -f ./packages/asl-search/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-search .
+      - docker build -f ./packages/asl-notifications/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-notifications .
   - name: scan-image
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
@@ -721,8 +953,8 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: asl-search
-      ALLOW_CVE_LIST_FILE: packages/asl-search/cve-exceptions.txt
+      IMAGE_NAME: asl-notifications
+      ALLOW_CVE_LIST_FILE: packages/asl-notifications/cve-exceptions.txt
       TIMEOUT: 10m
   - name: docker push
     image: docker:dind
@@ -736,25 +968,8 @@ steps:
         from_secret: quay_password
     commands:
       - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-search quay.io/ukhomeofficedigital/asl-search:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-search:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-search
-        --version $${DRONE_COMMIT_SHA}
+      - docker tag asl-notifications quay.io/ukhomeofficedigital/asl-notifications:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-notifications:$${DRONE_COMMIT_SHA}
     when:
       event:
         - push
@@ -762,10 +977,20 @@ steps:
         - main
 
 services:
-  - name: docker
-    image: docker:dind
-    environment:
-      DOCKER_TLS_CERTDIR: ""
+- name: docker
+  image: docker:dind
+  environment:
+    DOCKER_TLS_CERTDIR: ""
+- name: postgres
+  image: postgres
+  environment:
+    POSTGRES_USER: asl-test
+    POSTGRES_PASSWORD: test-password
+
+trigger:
+  event:
+    - push
+    - pull_request
 
 ---
 
@@ -868,23 +1093,6 @@ steps:
         - push
       branch:
         - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-permissions
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
 
 services:
   - name: docker
@@ -897,271 +1105,10 @@ services:
       POSTGRES_USER: asl-test
       POSTGRES_PASSWORD: test-password
 
----
-
-kind: pipeline
-name: asl-internal-api
-type: kubernetes
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: node:22.14.0
-    commands:
-      - git clone $DRONE_REMOTE_URL .
-  - name: changeset
-    image: node:22.14.0
-    environment:
-      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
-      SOURCE_COMMIT: "${DRONE_COMMIT}"
-      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
-      SKIP_STATUS: 78
-      MODULES: packages/asl-internal-api
-    commands:
-      - git config advice.detachedHead false
-      - git checkout $DRONE_COMMIT
-      - node ./ci/changeset.js --modules $MODULES
-      - git checkout $DRONE_TARGET_BRANCH
-      - git merge $DRONE_COMMIT
-      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
-  - name: install
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm ci --workspace asl-internal-api
-  - name: wait postgres
-    image: postgres
-    environment:
-      PGPASSWORD: test-password
-    commands:
-      - until psql -U asl-test -d asl-test -h postgres -c "SELECT 1;" >/dev/null 2>&1; do sleep 1; done
-  - name: test
-    image: node:22.14.0
-    environment:
-      DATABASE_NAME: asl-test
-      DATABASE_HOST: postgres
-      DATABASE_USERNAME: asl-test
-      DATABASE_PASSWORD: test-password
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run test --workspace asl-internal-api
-  - name: audit
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm audit --workspace=asl-internal-api --audit-level=high --omit=dev
-  - name: docker build
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      DOCKER_BUILDKIT: 1
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - docker build -f ./packages/asl-internal-api/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-internal-api .
-  - name: scan-image
-    pull: always
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
-    resources:
-      limits:
-        cpu: 1000
-        memory: 1024Mi
-    environment:
-      IMAGE_NAME: asl-internal-api
-      ALLOW_CVE_LIST_FILE: packages/asl-internal-api/cve-exceptions.txt
-      TIMEOUT: 10m
-  - name: docker push
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-      DOCKER_PASSWORD:
-        from_secret: quay_password
-    commands:
-      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-internal-api quay.io/ukhomeofficedigital/asl-internal-api:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-internal-api:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-internal-api
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-
-services:
-- name: docker
-  image: docker:dind
-  environment:
-    DOCKER_TLS_CERTDIR: ""
-- name: postgres
-  image: postgres
-  environment:
-    POSTGRES_USER: asl-test
-    POSTGRES_PASSWORD: test-password
-
----
-
-kind: pipeline
-name: asl-resolver
-type: kubernetes
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: node:22.14.0
-    commands:
-      - git clone $DRONE_REMOTE_URL .
-  - name: changeset
-    image: node:22.14.0
-    environment:
-      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
-      SOURCE_COMMIT: "${DRONE_COMMIT}"
-      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
-      SKIP_STATUS: 78
-      MODULES: packages/asl-resolver
-    commands:
-      - git config advice.detachedHead false
-      - git checkout $DRONE_COMMIT
-      - node ./ci/changeset.js --modules $MODULES
-      - git checkout $DRONE_TARGET_BRANCH
-      - git merge $DRONE_COMMIT
-      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
-  - name: install
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm ci --workspace asl-resolver
-  - name: test
-    image: node:22.14.0
-    environment:
-      DATABASE_NAME: asl-test
-      DATABASE_HOST: postgres
-      DATABASE_USERNAME: asl-test
-      DATABASE_PASSWORD: test-password
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run test --workspace asl-resolver
-  - name: audit
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm audit --workspace=asl-resolver --audit-level=high --omit=dev
-  - name: docker build
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      DOCKER_BUILDKIT: 1
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - docker build -f ./packages/asl-resolver/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-resolver .
-  - name: scan-image
-    pull: always
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
-    resources:
-      limits:
-        cpu: 1000
-        memory: 1024Mi
-    environment:
-      IMAGE_NAME: asl-resolver
-      ALLOW_CVE_LIST_FILE: packages/asl-resolver/cve-exceptions.txt
-      TIMEOUT: 10m
-  - name: docker push
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-      DOCKER_PASSWORD:
-        from_secret: quay_password
-    commands:
-      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-resolver quay.io/ukhomeofficedigital/asl-resolver:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-resolver:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-resolver
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-
-services:
-- name: docker
-  image: docker:dind
-  environment:
-    DOCKER_TLS_CERTDIR: ""
-- name: postgres
-  image: postgres
-  environment:
-    POSTGRES_USER: asl-test
-    POSTGRES_PASSWORD: test-password
+trigger:
+  event:
+    - push
+    - pull_request
 
 ---
 
@@ -1270,18 +1217,119 @@ steps:
         - push
       branch:
         - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
+
+services:
+- name: docker
+  image: docker:dind
+  environment:
+    DOCKER_TLS_CERTDIR: ""
+- name: postgres
+  image: postgres
+  environment:
+    POSTGRES_USER: asl-test
+    POSTGRES_PASSWORD: test-password
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+
+kind: pipeline
+name: asl-resolver
+type: kubernetes
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: node:22.14.0
     commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-public-api
-        --version $${DRONE_COMMIT_SHA}
+      - git clone $DRONE_REMOTE_URL .
+  - name: changeset
+    image: node:22.14.0
+    environment:
+      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
+      SKIP_STATUS: 78
+      MODULES: packages/asl-resolver
+    commands:
+      - git config advice.detachedHead false
+      - git checkout $DRONE_COMMIT
+      - node ./ci/changeset.js --modules $MODULES
+      - git checkout $DRONE_TARGET_BRANCH
+      - git merge $DRONE_COMMIT
+      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
+  - name: install
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm ci --workspace asl-resolver
+  - name: test
+    image: node:22.14.0
+    environment:
+      DATABASE_NAME: asl-test
+      DATABASE_HOST: postgres
+      DATABASE_USERNAME: asl-test
+      DATABASE_PASSWORD: test-password
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run test --workspace asl-resolver
+  - name: audit
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm audit --workspace=asl-resolver --audit-level=high --omit=dev
+  - name: docker build
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_BUILDKIT: 1
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - docker build -f ./packages/asl-resolver/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-resolver .
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: asl-resolver
+      ALLOW_CVE_LIST_FILE: packages/asl-resolver/cve-exceptions.txt
+      TIMEOUT: 10m
+  - name: docker push
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+      DOCKER_PASSWORD:
+        from_secret: quay_password
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl-resolver quay.io/ukhomeofficedigital/asl-resolver:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-resolver:$${DRONE_COMMIT_SHA}
     when:
       event:
         - push
@@ -1299,10 +1347,15 @@ services:
     POSTGRES_USER: asl-test
     POSTGRES_PASSWORD: test-password
 
+trigger:
+  event:
+    - push
+    - pull_request
+
 ---
 
 kind: pipeline
-name: asl-workflow
+name: asl-schema
 type: kubernetes
 
 clone:
@@ -1320,7 +1373,7 @@ steps:
       SOURCE_COMMIT: "${DRONE_COMMIT}"
       BUILD_EVENT: "${DRONE_BUILD_EVENT}"
       SKIP_STATUS: 78
-      MODULES: packages/asl-workflow
+      MODULES: packages/asl-schema
     commands:
       - git config advice.detachedHead false
       - git checkout $DRONE_COMMIT
@@ -1336,41 +1389,20 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm ci --workspace asl-workflow
-  - name: wait postgres
-    image: postgres
-    environment:
-      PGHOST: postgres
-      PGUSER: postgres
-      PGPASSWORD: test-password
-    commands:
-      - until psql -c "SELECT 1;" >/dev/null 2>&1; do sleep 1; done
-  - name: database setup
-    image: postgres
-    environment:
-      PGHOST: postgres
-      PGUSER: postgres
-      PGPASSWORD: test-password
-    commands:
-      - psql -c 'CREATE DATABASE "asl-test"'
-      - psql -c 'CREATE DATABASE "taskflow-test"'
+      - npm ci --workspace @asl/schema
   - name: test
     image: node:22.14.0
     environment:
-      ASL_DATABASE_HOST: postgres
-      ASL_DATABASE_NAME: asl-test
-      ASL_DATABASE_USERNAME: postgres
-      ASL_DATABASE_PASSWORD: test-password
+      DATABASE_NAME: asl-test
       DATABASE_HOST: postgres
-      DATABASE_NAME: taskflow-test
-      DATABASE_USERNAME: postgres
+      DATABASE_USERNAME: asl-test
       DATABASE_PASSWORD: test-password
       ART_AUTH_TOKEN:
         from_secret: art_auth_token
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm test --workspace asl-workflow
+      - npm test --workspace @asl/schema
   - name: audit
     image: node:22.14.0
     environment:
@@ -1379,7 +1411,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm audit --workspace=asl-workflow --audit-level=high --omit=dev
+      - npm audit --workspace=@asl/schema --audit-level=high --omit=dev
   - name: docker build
     image: docker:dind
     environment:
@@ -1390,7 +1422,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - docker build -f ./packages/asl-workflow/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-workflow .
+      - docker build -f ./packages/asl-schema/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-schema .
   - name: scan-image
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
@@ -1399,8 +1431,8 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: asl-workflow
-      ALLOW_CVE_LIST_FILE: packages/asl-workflow/cve-exceptions.txt
+      IMAGE_NAME: asl-schema
+      ALLOW_CVE_LIST_FILE: packages/asl-schema/cve-exceptions.txt
       TIMEOUT: 10m
   - name: docker push
     image: docker:dind
@@ -1414,290 +1446,8 @@ steps:
         from_secret: quay_password
     commands:
       - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-workflow quay.io/ukhomeofficedigital/asl-workflow:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-workflow:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-workflow
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-
-services:
-- name: docker
-  image: docker:dind
-  environment:
-    DOCKER_TLS_CERTDIR: ""
-- name: postgres
-  image: postgres
-  environment:
-    POSTGRES_USER: postgres
-    POSTGRES_PASSWORD: test-password
-
----
-
-kind: pipeline
-name: asl-internal-ui
-type: kubernetes
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: node:22.14.0
-    commands:
-      - git clone $DRONE_REMOTE_URL .
-  - name: changeset
-    image: node:22.14.0
-    environment:
-      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
-      SOURCE_COMMIT: "${DRONE_COMMIT}"
-      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
-      SKIP_STATUS: 78
-      MODULES: packages/asl-internal-ui
-    commands:
-      - git config advice.detachedHead false
-      - git checkout $DRONE_COMMIT
-      - node ./ci/changeset.js --modules $MODULES
-      - git checkout $DRONE_TARGET_BRANCH
-      - git merge $DRONE_COMMIT
-      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
-  - name: install
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm ci --workspace asl-internal-ui
-  - name: test
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run test --workspace asl-internal-ui
-  - name: audit
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm audit --workspace=asl-internal-ui --audit-level=high --omit=dev
-  - name: compile
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run build --workspace asl-internal-ui --production
-  - name: docker build
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      DOCKER_BUILDKIT: 1
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - docker build -f ./packages/asl-internal-ui/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-internal-ui .
-  - name: scan-image
-    pull: always
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
-    resources:
-      limits:
-        cpu: 1000
-        memory: 1024Mi
-    environment:
-      IMAGE_NAME: asl-internal-ui
-      ALLOW_CVE_LIST_FILE: packages/asl-internal-ui/cve-exceptions.txt
-      TIMEOUT: 10m
-  - name: docker push
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-      DOCKER_PASSWORD:
-        from_secret: quay_password
-    commands:
-      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-internal-ui quay.io/ukhomeofficedigital/asl-internal-ui:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-internal-ui:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-internal-ui
-        --version $${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-
-services:
-- name: docker
-  image: docker:dind
-  environment:
-    DOCKER_TLS_CERTDIR: ""
-
----
-
-kind: pipeline
-name: asl
-type: kubernetes
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: node:22.14.0
-    commands:
-      - git clone $DRONE_REMOTE_URL .
-  - name: changeset
-    image: node:22.14.0
-    environment:
-      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
-      SOURCE_COMMIT: "${DRONE_COMMIT}"
-      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
-      SKIP_STATUS: 78
-      MODULES: packages/asl
-    commands:
-      - git config advice.detachedHead false
-      - git checkout $DRONE_COMMIT
-      - node ./ci/changeset.js --modules $MODULES
-      - git checkout $DRONE_TARGET_BRANCH
-      - git merge $DRONE_COMMIT
-      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
-  - name: install
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm ci --workspace asl
-  - name: test
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run test --workspace asl
-  - name: audit
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm audit --workspace=asl --audit-level=high --omit=dev
-  - name: compile
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm run build --workspace asl --production
-  - name: docker build
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      DOCKER_BUILDKIT: 1
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - docker build -f ./packages/asl/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl .
-  - name: scan-image
-    pull: always
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
-    resources:
-      limits:
-        cpu: 1000
-        memory: 1024Mi
-    environment:
-      IMAGE_NAME: asl
-      ALLOW_CVE_LIST_FILE: packages/asl/cve-exceptions.txt
-      TIMEOUT: 10m
-  - name: docker push
-    image: docker:dind
-    environment:
-      DOCKER_HOST: tcp://docker:2375
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-      DOCKER_PASSWORD:
-        from_secret: quay_password
-    commands:
-      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl quay.io/ukhomeofficedigital/asl:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl
-        --version $${DRONE_COMMIT_SHA}
+      - docker tag asl-schema quay.io/ukhomeofficedigital/asl-schema:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-schema:$${DRONE_COMMIT_SHA}
     when:
       event:
         - push
@@ -1709,6 +1459,197 @@ services:
     image: docker:dind
     environment:
       DOCKER_TLS_CERTDIR: ""
+  - name: postgres
+    image: postgres
+    environment:
+      POSTGRES_USER: asl-test
+      POSTGRES_PASSWORD: test-password
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+
+kind: pipeline
+name: asl-search
+type: kubernetes
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: node:22.14.0
+    commands:
+      - git clone $DRONE_REMOTE_URL .
+  - name: changeset
+    image: node:22.14.0
+    environment:
+      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
+      SKIP_STATUS: 78
+      MODULES: packages/asl-search
+    commands:
+      - git config advice.detachedHead false
+      - git checkout $DRONE_COMMIT
+      - node ./ci/changeset.js --modules $MODULES
+      - git checkout $DRONE_TARGET_BRANCH
+      - git merge $DRONE_COMMIT
+      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
+  - name: install
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm ci --workspace asl-search
+  - name: test
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm run test --workspace asl-search
+  - name: audit
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm audit --workspace=asl-search --audit-level=high --omit=dev
+  - name: docker build
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_BUILDKIT: 1
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - docker build -f ./packages/asl-search/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-search .
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: asl-search
+      ALLOW_CVE_LIST_FILE: packages/asl-search/cve-exceptions.txt
+      TIMEOUT: 10m
+  - name: docker push
+    image: docker:dind
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+      DOCKER_PASSWORD:
+        from_secret: quay_password
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl-search quay.io/ukhomeofficedigital/asl-search:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-search:$${DRONE_COMMIT_SHA}
+    when:
+      event:
+        - push
+      branch:
+        - main
+
+services:
+  - name: docker
+    image: docker:dind
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+
+kind: pipeline
+name: asl-taskflow
+type: kubernetes
+
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: node:22.14.0
+    commands:
+      - git clone $DRONE_REMOTE_URL .
+  - name: changeset
+    image: node:22.14.0
+    environment:
+      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
+      SOURCE_COMMIT: "${DRONE_COMMIT}"
+      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
+      SKIP_STATUS: 78
+      MODULES: packages/asl-taskflow
+    commands:
+      - git config advice.detachedHead false
+      - git checkout $DRONE_COMMIT
+      - node ./ci/changeset.js --modules $MODULES
+      - git checkout $DRONE_TARGET_BRANCH
+      - git merge $DRONE_COMMIT
+      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
+  - name: install
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm ci --workspace @ukhomeoffice/asl-taskflow
+  - name: database setup
+    image: postgres
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: test-password
+    commands:
+      - psql -c 'CREATE DATABASE "taskflow-test"'
+  - name: test
+    image: node:22.14.0
+    commands:
+      - npm run test --workspace @ukhomeoffice/asl-taskflow
+  - name: audit
+    image: node:22.14.0
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm audit --workspace=@ukhomeoffice/asl-taskflow --audit-level=high --omit=dev
+
+services:
+  - name: postgres
+    image: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: test-password
+
+trigger:
+  event:
+    - push
+    - pull_request
 
 ---
 
@@ -1867,7 +1808,7 @@ trigger:
 ---
 
 kind: pipeline
-name: asl-taskflow
+name: asl-workflow
 type: kubernetes
 
 clone:
@@ -1885,7 +1826,7 @@ steps:
       SOURCE_COMMIT: "${DRONE_COMMIT}"
       BUILD_EVENT: "${DRONE_BUILD_EVENT}"
       SKIP_STATUS: 78
-      MODULES: packages/asl-taskflow
+      MODULES: packages/asl-workflow
     commands:
       - git config advice.detachedHead false
       - git checkout $DRONE_COMMIT
@@ -1901,7 +1842,15 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm ci --workspace @ukhomeoffice/asl-taskflow
+      - npm ci --workspace asl-workflow
+  - name: wait postgres
+    image: postgres
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: test-password
+    commands:
+      - until psql -c "SELECT 1;" >/dev/null 2>&1; do sleep 1; done
   - name: database setup
     image: postgres
     environment:
@@ -1909,79 +1858,25 @@ steps:
       PGUSER: postgres
       PGPASSWORD: test-password
     commands:
+      - psql -c 'CREATE DATABASE "asl-test"'
       - psql -c 'CREATE DATABASE "taskflow-test"'
   - name: test
     image: node:22.14.0
-    commands:
-      - npm run test --workspace @ukhomeoffice/asl-taskflow
-  - name: audit
-    image: node:22.14.0
     environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm audit --workspace=@ukhomeoffice/asl-taskflow --audit-level=high --omit=dev
-
-services:
-  - name: postgres
-    image: postgres
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: test-password
-
----
-
-kind: pipeline
-name: asl-schema
-type: kubernetes
-
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: node:22.14.0
-    commands:
-      - git clone $DRONE_REMOTE_URL .
-  - name: changeset
-    image: node:22.14.0
-    environment:
-      TARGET_BRANCH: "${DRONE_TARGET_BRANCH}"
-      SOURCE_COMMIT: "${DRONE_COMMIT}"
-      BUILD_EVENT: "${DRONE_BUILD_EVENT}"
-      SKIP_STATUS: 78
-      MODULES: packages/asl-schema
-    commands:
-      - git config advice.detachedHead false
-      - git checkout $DRONE_COMMIT
-      - node ./ci/changeset.js --modules $MODULES
-      - git checkout $DRONE_TARGET_BRANCH
-      - git merge $DRONE_COMMIT
-      - echo "$(node ./ci/modulepaths.js $MODULES)" > .module-paths
-  - name: install
-    image: node:22.14.0
-    environment:
-      ART_AUTH_TOKEN:
-        from_secret: art_auth_token
-      GITHUB_AUTH_TOKEN:
-        from_secret: github_token
-    commands:
-      - npm ci --workspace @asl/schema
-  - name: test
-    image: node:22.14.0
-    environment:
-      DATABASE_NAME: asl-test
+      ASL_DATABASE_HOST: postgres
+      ASL_DATABASE_NAME: asl-test
+      ASL_DATABASE_USERNAME: postgres
+      ASL_DATABASE_PASSWORD: test-password
       DATABASE_HOST: postgres
-      DATABASE_USERNAME: asl-test
+      DATABASE_NAME: taskflow-test
+      DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: test-password
       ART_AUTH_TOKEN:
         from_secret: art_auth_token
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm test --workspace @asl/schema
+      - npm test --workspace asl-workflow
   - name: audit
     image: node:22.14.0
     environment:
@@ -1990,7 +1885,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - npm audit --workspace=@asl/schema --audit-level=high --omit=dev
+      - npm audit --workspace=asl-workflow --audit-level=high --omit=dev
   - name: docker build
     image: docker:dind
     environment:
@@ -2001,7 +1896,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
     commands:
-      - docker build -f ./packages/asl-schema/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-schema .
+      - docker build -f ./packages/asl-workflow/Dockerfile --build-arg MODULE_PATHS="$(cat .module-paths)" --secret id=token,env=ART_AUTH_TOKEN --secret id=github_token,env=GITHUB_AUTH_TOKEN -t asl-workflow .
   - name: scan-image
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
@@ -2010,8 +1905,8 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: asl-schema
-      ALLOW_CVE_LIST_FILE: packages/asl-schema/cve-exceptions.txt
+      IMAGE_NAME: asl-workflow
+      ALLOW_CVE_LIST_FILE: packages/asl-workflow/cve-exceptions.txt
       TIMEOUT: 10m
   - name: docker push
     image: docker:dind
@@ -2025,25 +1920,8 @@ steps:
         from_secret: quay_password
     commands:
       - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag asl-schema quay.io/ukhomeofficedigital/asl-schema:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/asl-schema:$${DRONE_COMMIT_SHA}
-    when:
-      event:
-        - push
-      branch:
-        - main
-  - name: update manifest
-    image: quay.io/ukhomeofficedigital/asl-deploy-bot:latest
-    environment:
-      GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
-    commands:
-      - update
-        --repo ukhomeoffice/asl-deployments
-        --token $${GITHUB_ACCESS_TOKEN}
-        --file versions.yml
-        --service asl-schema
-        --version $${DRONE_COMMIT_SHA}
+      - docker tag asl-workflow quay.io/ukhomeofficedigital/asl-workflow:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/asl-workflow:$${DRONE_COMMIT_SHA}
     when:
       event:
         - push
@@ -2051,15 +1929,15 @@ steps:
         - main
 
 services:
-  - name: docker
-    image: docker:dind
-    environment:
-      DOCKER_TLS_CERTDIR: ""
-  - name: postgres
-    image: postgres
-    environment:
-      POSTGRES_USER: asl-test
-      POSTGRES_PASSWORD: test-password
+- name: docker
+  image: docker:dind
+  environment:
+    DOCKER_TLS_CERTDIR: ""
+- name: postgres
+  image: postgres
+  environment:
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: test-password
 
 trigger:
   event:

--- a/ci/deployset.js
+++ b/ci/deployset.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+"use strict";
+
+const { parseArgs } = require("node:util")
+const common = require("./common")
+const { log, getBuildInfo } = common
+
+// Constants
+
+const BUILD_STATUS_FAILURE = "failure"
+const BUILD_STATUS_SUCCESS = "success"
+
+// Functions
+
+const collectEnvironment = () => {
+    return {
+        DRONE_SERVER: process.env.DRONE_SERVER,
+        DRONE_TOKEN: process.env.DRONE_TOKEN,
+        DRONE_REPO_OWNER: process.env.DRONE_REPO_OWNER,
+        DRONE_REPO_NAME: process.env.DRONE_REPO_NAME,
+        DRONE_BUILD_NUMBER: process.env.DRONE_BUILD_NUMBER,
+        SKIP_STATUS: process.env.SKIP_STATUS,
+    }
+}
+
+const collectArguments = () => {
+    return parseArgs({
+        options: {
+            backoff: { type: "string", default: "10", short: "b" },
+            help: { type: "boolean", short: "h" },
+        },
+        allowPositionals: true,
+    })
+}
+
+const collectDeployStages = async (backoff, positionals, environment) => {
+    const pendingDeployStages = positionals.reduce((acc, stage) => (acc[stage] = true, acc), {})
+    const completedDeployStages = {}
+    
+    while (Object.keys(pendingDeployStages).length > 0) {
+        log(`\nPending build stages: ${Object.keys(pendingDeployStages).join(", ")}`)
+        log(`Collected deploy stages: ${Object.keys(completedDeployStages).join(", ")}`)
+        log(`Polling build info endpoint in ${backoff} seconds...`)
+        await new Promise(resolve => setTimeout(resolve, backoff * 1000))
+
+        const build = await getBuildInfo(
+            environment.DRONE_SERVER, 
+            environment.DRONE_REPO_OWNER, 
+            environment.DRONE_REPO_NAME, 
+            environment.DRONE_BUILD_NUMBER, 
+            environment.DRONE_TOKEN,
+        )
+
+        if (build.status === BUILD_STATUS_FAILURE) {
+            throw new Error(`Build failed: ${build.status}`)
+        }
+
+        for (const buildStage of build.stages) {
+            if (buildStage.status === BUILD_STATUS_FAILURE) {
+                throw new Error(`Build stage '${buildStage.name}' failed: ${buildStage.status}`)
+            }
+        }
+
+        for (const deployStageName of Object.keys(pendingDeployStages)) {
+            const deployStage = build.stages.find(stage => stage.name === deployStageName)
+            if (!deployStage) {
+                throw new Error(`Build stage '${deployStageName}' not found`)
+            }
+            if (deployStage.status !== BUILD_STATUS_SUCCESS) {
+                continue
+            }
+            if (pendingDeployStages[deployStageName]) {
+                log(`Build stage '${deployStageName}' completed`)
+                delete pendingDeployStages[deployStageName]
+            }
+            if (deployStage.steps.every(step => step.exit_code === 0)) {
+                log(`Build stage '${deployStageName}' will be deployed`)
+                completedDeployStages[deployStageName] = true
+            }
+        }
+    }
+
+    return Object.keys(completedDeployStages)
+}
+
+// Commands
+
+const help = () => {
+    log("Usage: deployset <stage-1> [stage-2] [...]")
+    log("\nDescription: poll the drone build info endpoint until all parameterized stages are complete then return deployable stages")
+    log(`\nOptions:`);
+    log("  -h, --help  Display this help message")
+}
+
+const main = async ({ values, positionals }) => {
+    const ENVIRONMENT = collectEnvironment()
+
+    if (values.help) {
+        help();
+        process.exit(0);
+    }
+
+    for (const [key, value] of Object.entries(ENVIRONMENT)) {
+        if (!value) {
+            throw new Error(`Environment variable '${key}' not set`)
+        }
+    }
+
+    if (positionals.length === 0) {
+        throw new Error("Must provide at least one stage")
+    }
+
+    log("Collecting deploy stages...")
+
+    const deployStages = await collectDeployStages(parseInt(values.backoff), positionals, ENVIRONMENT)
+
+    if (deployStages.length === 0) {
+        log("\nNo stages to deploy")
+    } else {
+        log(`\nFound stages to deploy: ${deployStages.join(", ")}`)
+    }
+    
+    return deployStages;
+}
+
+// Run
+
+if (require.main === module) {
+    (async () => {
+        let stages;
+        try {
+            stages = await main(collectArguments())
+        } catch (err) {
+            log(err.message)
+            process.exit(1)
+        }
+        if (stages.length === 0) {
+            log("\nNo stages to deploy")
+            process.exit(process.env.SKIP_STATUS)
+        }
+        log(`\nFound stages to deploy: ${stages.join(", ")}`)
+        console.log(stages.join(" "))
+        process.exit(0)
+    })()
+}
+
+module.exports = main

--- a/ci/deployset.test.js
+++ b/ci/deployset.test.js
@@ -1,0 +1,331 @@
+const { describe, it, before, after, afterEach } = require("node:test");
+const assert = require("node:assert").strict;
+const proxyquire = require("proxyquire").noPreserveCache()
+
+describe("deployset", () => {
+    let env = process.env
+    let stderr = process.stderr.write
+
+    const validEnv = () => ({
+        DRONE_SERVER: "test-drone-server", 
+        DRONE_TOKEN: "test-drone-token", 
+        DRONE_REPO_NAME: "test-repo-name", 
+        DRONE_REPO_OWNER: "test-repo-owner", 
+        DRONE_BUILD_NUMBER: "test-build-number",
+        SKIP_STATUS: "test-skip-status"
+    })
+
+    before(() => {
+        process.stderr.write = () => {}
+    })
+
+    after(() => {
+        process.stderr.write = stderr
+    })
+
+    afterEach(() => {
+        process.env = env
+    })
+
+    describe("when using valid parameters", () => {
+        describe("when all steps for a stage exit with code 0", () => {
+            it("should output the stage", async () => {
+                process.env = {...process.env, ...validEnv()}
+                const deployset = proxyquire("./deployset", {
+                    "./common": {
+                        getBuildInfo: async () => ({
+                            stages: [
+                                {
+                                    name: "test-stage",
+                                    status: "success",
+                                    steps: [
+                                        {
+                                            name: "test-step",
+                                            exit_code: 0,
+                                        },
+                                    ]
+                                }
+                            ],
+                        })
+                    } 
+                })
+                const stages = await deployset({ values: { backoff: 0 }, positionals: ["test-stage"] })
+                assert.deepEqual(stages, ["test-stage"], "Expected stages to be output")
+            })
+        })
+
+        describe("when a step for a stage exits with non-zero code", () => {
+            it("should not output the stage", async () => {
+                process.env = {...process.env, ...validEnv()}
+                const deployset = proxyquire("./deployset", {
+                    "./common": {
+                        getBuildInfo: async () => ({
+                            stages: [
+                                {
+                                    name: "test-stage",
+                                    status: "success",
+                                    steps: [
+                                        {
+                                            name: "test-step",
+                                            exit_code: 78,
+                                        },
+                                    ]
+                                }
+                            ],
+                        })
+                    } 
+                })
+                const stages = await deployset({ values: { backoff: 0 }, positionals: ["test-stage"] })
+                assert.deepEqual(stages, [], "Expected no stages to be output")
+            })
+        })
+
+        describe("when multiple stages complete across several polling intervals", () => {
+            it("should output the stages", async () => {
+                process.env = {...process.env, ...validEnv()}
+                const deployset = proxyquire("./deployset", {
+                    "./common": {
+                        getBuildInfo: (() => {
+                            let count = 0
+                            return async () => {
+                                switch (count++) {
+                                    case 0: {
+                                        return {
+                                            stages: [
+                                                {
+                                                    name: "test-stage-1",
+                                                    status: "success",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-1",
+                                                            exit_code: 0,
+                                                        },
+                                                    ]
+                                                },
+                                                {
+                                                    name: "test-stage-2",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-2",
+                                                        },
+                                                    ]
+                                                },
+                                                {
+                                                    name: "test-stage-3",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-3",
+                                                        },
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                    case 1: {
+                                        return {
+                                            stages: [
+                                                {
+                                                    name: "test-stage-1",
+                                                    status: "success",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-1",
+                                                            exit_code: 0,
+                                                        },
+                                                    ]
+                                                },
+                                                {
+                                                    name: "test-stage-2",
+                                                    status: "success",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-2",
+                                                            exit_code: 0,
+                                                        },
+                                                    ]
+                                                },
+                                                {
+                                                    name: "test-stage-3",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-3",
+                                                        },
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                    case 2: {
+                                        return {
+                                            stages: [
+                                                {
+                                                    name: "test-stage-1",
+                                                    status: "success",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-1",
+                                                            exit_code: 0,
+                                                        },
+                                                    ]
+                                                },
+                                                {
+                                                    name: "test-stage-2",
+                                                    status: "success",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-2",
+                                                            exit_code: 0,
+                                                        },
+                                                    ]
+                                                },
+                                                {
+                                                    name: "test-stage-3",
+                                                    status: "success",
+                                                    steps: [
+                                                        {
+                                                            name: "test-step-3",
+                                                            exit_code: 78
+                                                        },
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                    default:
+                                        throw new Error("Unexpected call to getBuildInfo")
+                                }
+                            }
+                        })()
+                    },
+                })
+                const stages = await deployset({ values: { backoff: 0 }, positionals: ["test-stage-1", "test-stage-2", "test-stage-3"] })
+                assert.deepEqual(stages, ["test-stage-1", "test-stage-2"], "Expected stages to be output")
+            })
+        })
+
+        describe("when the build fails", () => {
+            it("should throw an error", async () => {
+                process.env = {...process.env, ...validEnv()}
+                try {
+                    const deployset = proxyquire("./deployset", {
+                        "./common": {
+                            getBuildInfo: async () => ({
+                                status: "failure",
+                            })
+                        } 
+                    })
+                    await deployset({ values: { backoff: 0 }, positionals: ["test-stage"] })
+                } catch (err) {
+                    assert.ok(err instanceof Error, "Expected an error to be thrown")
+                    return
+                }
+                assert.fail("Expected an error to be thrown")
+            })
+        })
+
+        describe("when a build stage fails", () => {
+            it("should throw an error", async () => {
+                process.env = {...process.env, ...validEnv()}
+                try {
+                    const deployset = proxyquire("./deployset", {
+                        "./common": {
+                            getBuildInfo: async () => ({
+                                stages: [
+                                    {
+                                        name: "test-stage",
+                                        status: "failure",
+                                    }
+                                ]
+                            })
+                        } 
+                    })
+                    await deployset({ values: { backoff: 0 }, positionals: ["test-stage"] })
+                } catch (err) {
+                    assert.ok(err instanceof Error, "Expected an error to be thrown")
+                    return
+                }
+                assert.fail("Expected an error to be thrown")
+            })
+        })
+    })
+
+    describe("when using invalid parameters", () => {
+        describe("when using invalid environment variables", () => {
+            const tests = [
+                { name: "missing DRONE_SERVER", env: () => ({...validEnv(), DRONE_SERVER: undefined}) },
+                { name: "missing DRONE_TOKEN", env: () => ({...validEnv(), DRONE_TOKEN: undefined}) },
+                { name: "missing DRONE_REPO_NAME", env: () => ({...validEnv(), DRONE_REPO_NAME: undefined}) },
+                { name: "missing DRONE_REPO_OWNER", env: () => ({...validEnv(), DRONE_REPO_OWNER: undefined}) },
+                { name: "missing DRONE_BUILD_NUMBER", env: () => ({...validEnv(), DRONE_BUILD_NUMBER: undefined}) },
+                { name: "missing SKIP_STATUS", env: () => ({...validEnv(), SKIP_STATUS: undefined}) },
+            ]
+
+            for (const test of tests) {
+                it(`should throw an error when ${test.name}`, async () => {
+                    try {
+                        process.env = test.env()
+                        const deployset = proxyquire("./deployset", {
+                            "./common": {
+                                getBuildInfo: async () => ({
+                                    stages: [
+                                        {
+                                            name: "test-stage",
+                                            status: "success",
+                                            steps: [
+                                                {
+                                                    name: "test-step",
+                                                    exit_code: 0,
+                                                },
+                                            ]
+                                        }
+                                    ],
+                                })
+                            } 
+                        })
+                        await deployset({ values: { backoff: 0 }, positionals: ["test-stage"] })
+                    } catch (err) {
+                        assert.ok(err instanceof Error, "Expected an error to be thrown")
+                        return
+                    }
+                    assert.fail("Expected an error to be thrown")
+                })
+            }
+        })
+
+        describe("when using invalid arguments", () => {
+            const tests = [
+                {name: "no stages are provided", args: [], build: []},
+                {name: "a specified deploy stage is not a build stage", args: ["test-stage"], build: [{
+                    name: "other-stage",
+                    status: "success",
+                    steps: [
+                        {
+                            name: "test-step",
+                            exit_code: 0,
+                        },
+                    ]
+                }]},
+            ]
+
+            for (const test of tests) {
+                it(`should throw an error when ${test.name}`, async () => {
+                    process.env = {...process.env, ...validEnv()}
+                    const deployset = proxyquire("./deployset", {
+                        "./common": {
+                            getBuildInfo: async () => ({
+                                stages: test.build,
+                            })
+                        } 
+                    })
+                    try {
+                        await deployset({ values: { backoff: 0 }, positionals: test.args })
+                    } catch (err) {
+                        assert.ok(err instanceof Error, "Expected an error to be thrown")
+                        return
+                    }
+                    assert.fail("Expected an error to be thrown")
+                })
+            }
+        })
+    })
+})

--- a/ci/manifest.js
+++ b/ci/manifest.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+"use strict";
+
+const { parseArgs } = require("node:util")
+const path = require("node:path")
+const yaml = require("yaml")
+const common = require("./common")
+const { log, getGithubFile, writeGithubFile } = common
+
+// Functions
+
+const collectEnvironment = () => {
+    return {
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+        GITHUB_REPO_OWNER: process.env.GITHUB_REPO_OWNER,
+        GITHUB_REPO_NAME: process.env.GITHUB_REPO_NAME,
+        GITHUB_MANIFEST_PATH: process.env.GITHUB_MANIFEST_PATH,
+        SOURCE_COMMIT: process.env.SOURCE_COMMIT,
+        SOURCE_COMMIT_MESSAGE: process.env.SOURCE_COMMIT_MESSAGE,
+    }
+}
+
+const collectArguments = () => parseArgs({
+    options: {
+        help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+})
+
+const parseManifest = (manifest, ext) => {
+    switch (ext) {
+        case ".json":
+            return JSON.parse(manifest)
+        case ".yml":
+        case ".yaml":
+            return yaml.parse(manifest)
+        default:
+            throw new Error(`Unsupported manifest file extension: '${ext}'`)
+    }
+}
+
+const stringifyManifest = (manifest, ext) => {
+    switch (ext) {
+        case ".json":
+            return JSON.stringify(manifest, null, "  ")
+        case ".yml":
+        case ".yaml":
+            return yaml.stringify(manifest)
+        default:
+            throw new Error(`Unsupported manifest file extension: '${ext}'`)
+    }
+}
+
+const writeMessage = (msg, deployStages) => {
+    if (msg.match(/^Merge pull request/)) {
+        msg = msg.split('\n').slice(1).join('\n').trim();
+    }
+    msg = `${msg}\n\n`
+    for (const deployStage of deployStages) {
+        msg = `${msg}- ${deployStage}\n`
+    }
+    const head = deployStages.slice(0, 1)
+    const tail = deployStages.slice(1)
+    return `[${head}${tail.length > 0 ? `, +${tail.length}` : ""}] ${msg.trim()}`
+}
+
+// Commands
+
+const help = () => {
+    log("Usage: manifest [stage-1] [stage-2] [...]")
+    log("\nDescription: update the remote manifest with new image tags for deployed stages")
+    log(`\nOptions:`);
+    log("  -h, --help  Display this help message")
+}
+
+const main = async ({ values, positionals: deployStages }) => {
+    const ENVIRONMENT = collectEnvironment()
+
+    const {
+        GITHUB_TOKEN,
+        GITHUB_REPO_OWNER,
+        GITHUB_REPO_NAME,
+        GITHUB_MANIFEST_PATH,
+        SOURCE_COMMIT,
+        SOURCE_COMMIT_MESSAGE
+    } = ENVIRONMENT
+
+    if (values.help) {
+        help()
+        process.exit(0)
+    }
+
+    for (const [key, value] of Object.entries(ENVIRONMENT)) {
+        if (!value) {
+            throw new Error(`Environment variable '${key}' not set`)
+        }
+    }
+
+    if (deployStages.length === 0) {
+        throw new Error("Must provide at least one stage")
+    }
+
+    const manifestFileUrl = `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/contents/${GITHUB_MANIFEST_PATH}`
+    const manifestExt = path.extname(GITHUB_MANIFEST_PATH)
+
+    log(`Updating manifest '${GITHUB_MANIFEST_PATH}' in repository '${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}'`)
+
+    log(`Reading manifest from '${manifestFileUrl}'...`)
+    const {manifest, sha} = await getGithubFile(manifestFileUrl, GITHUB_TOKEN)
+
+    log(`Updating manifest...`)
+    const jsonManifest = parseManifest(manifest, manifestExt)
+    for (const deployStage of deployStages) {
+        if (!jsonManifest[deployStage]) {
+            log(`Deploy stage '${deployStage}' not found in manifest`)
+        }
+        log(`Updating deploy stage '${deployStage}' with source commit '${SOURCE_COMMIT}'`)
+        jsonManifest[deployStage] = SOURCE_COMMIT
+    }
+    const updatedManifest = stringifyManifest(jsonManifest, manifestExt)
+
+    log(`Manifest updated.\n`)
+    for (const [key, value] of Object.entries(jsonManifest)) {
+        log(`${key}: ${value}`)
+    }
+
+    log(`\nWriting updated manifest to '${manifestFileUrl}'...`)
+    const message = writeMessage(SOURCE_COMMIT_MESSAGE, deployStages)
+    await writeGithubFile(manifestFileUrl, sha, message, updatedManifest, GITHUB_TOKEN)
+}
+
+// Run
+
+if (require.main === module) {
+    (async () => {
+        try {
+            await main(collectArguments())
+        } catch (err) {
+            log(err.message)
+            process.exit(1)
+        }
+    })()
+}
+
+module.exports = main

--- a/ci/manifest.test.js
+++ b/ci/manifest.test.js
@@ -1,0 +1,194 @@
+const { describe, it, before, after, afterEach } = require("node:test");
+const assert = require("node:assert").strict;
+const proxyquire = require("proxyquire").noPreserveCache()
+const yaml = require("yaml")
+
+describe("manifest", () => {
+    let env = process.env
+    let stderr = process.stderr.write
+
+    const validEnv = () => ({
+        GITHUB_TOKEN: "test-github-token",
+        GITHUB_REPO_OWNER: "test-github-repo-owner",
+        GITHUB_REPO_NAME: "test-github-repo-name",
+        GITHUB_MANIFEST_PATH: "test-github-manifest-path.yml",
+        SOURCE_COMMIT: "test-source-commit",
+        SOURCE_COMMIT_MESSAGE: "test-source-commit-message",
+    })
+
+    before(() => {
+        process.stderr.write = () => {}
+    })
+
+    after(() => {
+        process.stderr.write = stderr
+    })
+
+    afterEach(() => {
+        process.env = env
+    })
+
+    describe("when using valid parameters", () => {
+        it("should write the updated manifest to github with one new source commit", async () => {
+            process.env = validEnv()
+            const manifest = proxyquire("./manifest", {
+                "./common": {
+                    getGithubFile: () => ({
+                        manifest: yaml.stringify({
+                            "test-stage": "original-source-commit",
+                            "test-stage-2": "original-source-commit-2",
+                        }),
+                        sha: "test-sha",
+                    }),
+                    writeGithubFile: (_, sha, message, content, token) => {
+                        assert.strictEqual(sha, "test-sha")
+                        assert.strictEqual(message, `[test-stage] test-source-commit-message\n\n- test-stage`)
+                        assert.strictEqual(content, yaml.stringify({
+                            "test-stage": process.env.SOURCE_COMMIT,
+                            "test-stage-2": "original-source-commit-2",
+                        }))
+                        assert.strictEqual(token, process.env.GITHUB_TOKEN)
+                    },
+                },
+            })
+            await manifest({ values: {}, positionals: ["test-stage"] })
+        })
+
+        it("should write the updated manifest to github with multiple new source commits", async () => {
+            process.env = validEnv()
+            const manifest = proxyquire("./manifest", {
+                "./common": {
+                    getGithubFile: () => ({
+                        manifest: yaml.stringify({
+                            "test-stage": "original-source-commit",
+                            "test-stage-2": "original-source-commit-2",
+                        }),
+                        sha: "test-sha",
+                    }),
+                    writeGithubFile: (_, sha, message, content, token) => {
+                        assert.strictEqual(sha, "test-sha")
+                        assert.strictEqual(message, "[test-stage, +1] test-source-commit-message\n\n- test-stage\n- test-stage-2")
+                        assert.strictEqual(content, yaml.stringify({
+                            "test-stage": process.env.SOURCE_COMMIT,
+                            "test-stage-2": process.env.SOURCE_COMMIT,
+                        }))
+                        assert.strictEqual(token, process.env.GITHUB_TOKEN)
+                    },
+                },
+            })
+            await manifest({ values: {}, positionals: ["test-stage", "test-stage-2"] })
+        })
+
+        describe("when getting the github file fails", () => {
+            it("should throw an error", async () => {
+                process.env = validEnv()
+                const manifest = proxyquire("./manifest", {
+                    "./common": {
+                        getGithubFile: () => {
+                            throw new Error("test-error")
+                        },
+                        writeGithubFile: () => ({}),
+                    },
+                })
+                try {
+                    await manifest({ values: {}, positionals: ["test-stage"] })
+                } catch (err) {
+                    assert.strictEqual(err.message, "test-error")
+                    return
+                }
+                assert.fail("Expected an error to be thrown")
+            })
+        })
+
+        describe("when writing the github file fails", () => {
+            it("should throw an error", async () => {
+                process.env = validEnv()
+                const manifest = proxyquire("./manifest", {
+                    "./common": {
+                        getGithubFile: () => ({
+                            manifest: yaml.stringify({
+                                "test-stage": "original-source-commit",
+                                "test-stage-2": "original-source-commit-2",
+                            }),
+                            sha: "test-sha",
+                        }),
+                        writeGithubFile: () => {
+                            throw new Error("test-error")
+                        },
+                    },
+                })
+                try {
+                    await manifest({ values: {}, positionals: ["test-stage"] })
+                } catch (err) {
+                    assert.strictEqual(err.message, "test-error")
+                    return
+                }
+                assert.fail("Expected an error to be thrown")
+            })
+        })
+    })
+
+    describe("when using invalid parameters", () => {
+        describe("when using inavlid environment variables", () => {
+            const tests = [
+                { name: "missing GITHUB_TOKEN", env: () => ({...validEnv(), GITHUB_TOKEN: undefined}) },
+                { name: "missing GITHUB_REPO_OWNER", env: () => ({...validEnv(), GITHUB_REPO_OWNER: undefined}) },
+                { name: "missing GITHUB_REPO_NAME", env: () => ({...validEnv(), GITHUB_REPO_NAME: undefined}) },
+                { name: "missing GITHUB_MANIFEST_PATH", env: () => ({...validEnv(), GITHUB_MANIFEST_PATH: undefined}) },
+                { name: "using invalid GITHUB_MANIFEST_PATH extension", env: () => ({...validEnv(), GITHUB_MANIFEST_PATH: "test-github-manifest-path.txt"}) },
+                { name: "missing SOURCE_COMMIT", env: () => ({...validEnv(), SOURCE_COMMIT: undefined}) },
+                { name: "missing SOURCE_COMMIT_MESSAGE", env: () => ({...validEnv(), SOURCE_COMMIT_MESSAGE: undefined}) },
+            ]
+
+            for (const test of tests) {
+                it(`should throw an error when ${test.name}`, async () => {
+                    process.env = test.env()
+                    const manifest = proxyquire("./manifest", {
+                        "./common": {
+                            getGithubFile: () => ({
+                                manifest: yaml.stringify({
+                                    "test-stage": "original-source-commit",
+                                    "test-stage-2": "original-source-commit-2",
+                                }),
+                                sha: "test-sha",
+                            }),
+                            writeGithubFile: () => ({}),
+                        },
+                    })
+                    try {
+                        await manifest({ values: {}, positionals: ["test-stage"] })
+                    } catch (err) {
+                        assert.ok(err instanceof Error, "Expected an error to be thrown")
+                        return
+                    }
+                    assert.fail("Expected an error to be thrown")
+                })
+            }
+        })
+
+        describe("when using invalid arguments", () => {
+            const tests = [
+                {name: "no stages are provided", args: []},
+            ]
+
+            for (const test of tests) {
+                it(`should throw an error when ${test.name}`, async () => {
+                    process.env = validEnv()
+                    const manifest = proxyquire("./manifest", {
+                        "./common": {
+                            getGithubFile: () => assert.fail("getGithubFile should not be called"),
+                            writeGithubFile: () => assert.fail("writeGithubFile should not be called"),
+                        },
+                    })
+                    try {
+                        await manifest({ values: {}, positionals: test.args })
+                    } catch (err) {
+                        assert.ok(err instanceof Error, "Expected an error to be thrown")
+                        return
+                    }
+                    assert.fail("Expected an error to be thrown")
+                })
+            }
+        })
+    })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "packages/*"
       ],
       "devDependencies": {
-        "concurrently": "^9.1.2"
+        "concurrently": "^9.1.2",
+        "proxyquire": "^2.1.3",
+        "yaml": "^2.7.1"
       }
     },
     "node_modules/@acuris/aws-es-connection": {
@@ -9693,6 +9695,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -11625,6 +11641,16 @@
       "engines": {
         "node": ">= 0.4"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14225,6 +14251,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -16402,6 +16435,18 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -21126,6 +21171,19 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "echo": "echo 'workspace is in action'"
   },
   "devDependencies": {
-    "concurrently": "^9.1.2"
+    "concurrently": "^9.1.2",
+    "proxyquire": "^2.1.3",
+    "yaml": "^2.7.1"
   },
   "overrides": {
     "node-fetch": "^2.6.11",


### PR DESCRIPTION
Add new deployset functionality to replace the old `asl-deploy-bot` which is not set up to handle a monorepo scenario. The updated `ci/README.md` contains an overview of the new deployment flow.

This new functionality allows us to update multiple containers on `asl-deployments` at the same time, while preventing updates where any part of the pipeline has failed and avoiding race conditions with the GitHub API.