### PR TITLE
Fix @asl/pages install

### DIFF
--- a/packages/asl-pages/.npmrc
+++ b/packages/asl-pages/.npmrc
@@ -1,8 +1,0 @@
-registry=https://registry.npmjs.org/
-
-@ukhomeoffice:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}
-
-@asl:registry = https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_authToken=${ART_AUTH_TOKEN}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:always-auth=true

--- a/packages/asl-pages/package.json
+++ b/packages/asl-pages/package.json
@@ -12,7 +12,8 @@
     "build": "npm run build:css",
     "build:css": "npm run build:css:app && npm run build:css:pdf",
     "build:css:app": "npm-sass ./pages/common/assets/sass/style.scss > ./pages/common/dist/css/app.css",
-    "build:css:pdf": "sass --no-source-map ./pages/common/assets/sass/pdf:./pages/common/dist/css/pdf"
+    "build:css:pdf": "sass --no-source-map ./pages/common/assets/sass/pdf:./pages/common/dist/css/pdf",
+    "postinstall": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The old `prepublish` script was removed as we no longer use npm, but the package still needs to be built before use. Added a `postinstall` script to build the `dist` files required by ui services.