### PR TITLE
exclude transfered rops.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,164 +47,16 @@
       "link": true
     },
     "node_modules/@asl/projects": {
-      "version": "15.10.4",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-15.10.4.tgz",
-      "integrity": "sha512-i9xcBNtLEkVvoD3qWkRdoas5xxJpKESt4tk+cIgiokGijP+4Qiw65S8rMkp1h0HkWKiuzMuFabQ5XfcC2W+Ibw==",
-      "license": "MIT",
-      "dependencies": {
-        "@asl/service": "^11.0.4",
-        "@asl/slate-edit-table": "0.0.3",
-        "@babel/core": "^7.24.4",
-        "@redux-devtools/extension": "^3.3.0",
-        "@ukhomeoffice/asl-components": "13.9.5",
-        "@ukhomeoffice/asl-constants": "^2.2.1",
-        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
-        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
-        "@ukhomeoffice/react-components": "^1.3.3",
-        "classnames": "^2.2.6",
-        "date-fns": "^3.6.0",
-        "details-element-polyfill": "^2.3.0",
-        "docx": "5.0.0-rc4",
-        "fast-array-diff": "^1.1.0",
-        "file-saver": "^2.0.0",
-        "immutable": "^3.8.2",
-        "is-hotkey": "^0.2.0",
-        "jsondiffpatch": "^0.4.1",
-        "jsonpath-plus": "^10.0.1",
-        "lodash": "^4.17.21",
-        "mdn-polyfills": "^5.15.0",
-        "minimatch": "^3.0.4",
-        "react": "^16.9.0",
-        "react-dom": "^16.6.0",
-        "react-icons-kit": "^1.1.6",
-        "react-markdown": "^6.0.2",
-        "react-redux": "^7.1.0",
-        "react-router": "^5.1.2",
-        "react-router-dom": "^5.0.1",
-        "react-router-hash-link": "^1.2.1",
-        "react-transition-group": "^1.2.1",
-        "redux": "^4.0.1",
-        "redux-thunk": "^2.3.0",
-        "remark-parse": "^9.0.0",
-        "sha.js": "^2.4.11",
-        "shasum": "^1.0.2",
-        "slate": "^0.47.8",
-        "slate-react": "^0.22.10",
-        "unified": "^9.2.2",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@asl/projects/node_modules/@asl/slate-edit-table": {
-      "version": "0.0.3",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
-      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
-      "license": "MIT",
-      "dependencies": {
-        "slate-schema-violations": "^0.1.39"
-      },
-      "peerDependencies": {
-        "immutable": "^3.8.2",
-        "slate": "^0.47.4",
-        "slate-react": "^0.22.4"
-      }
-    },
-    "node_modules/@asl/projects/node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "resolved": "packages/asl-projects",
+      "link": true
     },
     "node_modules/@asl/schema": {
       "resolved": "packages/asl-schema",
       "link": true
     },
     "node_modules/@asl/service": {
-      "version": "11.0.4",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
-      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/plugin-proposal-class-properties": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
-        "@babel/preset-env": "^7.24.4",
-        "@babel/preset-react": "^7.24.1",
-        "@babel/register": "^7.23.7",
-        "@lennym/redis-session": "^2.2.0",
-        "@redux-devtools/extension": "^3.3.0",
-        "@ukhomeoffice/asl-components": "13.9.5",
-        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
-        "aws-sdk": "^2.1370.0",
-        "babel-plugin-transform-require-ignore": "^0.1.1",
-        "body-parser": "^1.18.3",
-        "buffer": "^6.0.3",
-        "express": "^4.16.2",
-        "express-react-views": "^0.11.0",
-        "express-session": "^1.15.6",
-        "find-root": "^1.1.0",
-        "glob": "^7.1.2",
-        "helmet": "^3.21.1",
-        "helmet-csp": "^2.9.3",
-        "hot-shots": "^6.8.2",
-        "http-proxy": "^1.18.1",
-        "into-stream": "^4.0.0",
-        "js-base64": "^2.5.1",
-        "keycloak-connect": "^26.1.1",
-        "lodash": "^4.17.21",
-        "mkdirp": "^0.5.1",
-        "moment": "^2.29.4",
-        "morgan": "^1.9.1",
-        "mustache": "^2.3.2",
-        "on-finished": "^2.3.0",
-        "path-browserify": "^1.0.1",
-        "process": "^0.11.10",
-        "prop-types": "^15.8.1",
-        "qs": "^6.5.2",
-        "r2": "^2.0.1",
-        "react": "^16.9.0",
-        "react-dom": "^16.4.2",
-        "react-markdown": "^6.0.2",
-        "react-redux": "^7.1.0",
-        "redux": "^4.0.0",
-        "redux-logger": "^3.0.6",
-        "redux-thunk": "^2.3.0",
-        "set-immediate-shim": "^2.0.0",
-        "terser-webpack-plugin": "^4.2.3",
-        "url": "^0.11.0",
-        "url-search-params": "^1.1.0",
-        "uuid": "^8.3.2",
-        "winston": "^3.2.1"
-      },
-      "peerDependencies": {
-        "webpack": "^5.69.1"
-      }
-    },
-    "node_modules/@asl/service/node_modules/hot-shots": {
-      "version": "6.8.7",
-      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
-      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "optionalDependencies": {
-        "unix-dgram": "2.0.x"
-      }
-    },
-    "node_modules/@asl/service/node_modules/mustache": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
-      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      },
-      "engines": {
-        "npm": ">=1.4.0"
-      }
+      "resolved": "packages/asl-service",
+      "link": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -4199,66 +4051,16 @@
       }
     },
     "node_modules/@ukhomeoffice/asl-components": {
-      "version": "13.9.5",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
-      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ukhomeoffice/asl-constants": "^2.2.1",
-        "@ukhomeoffice/asl-dictionary": "^2.1.0",
-        "@ukhomeoffice/react-components": "^1.4.2",
-        "@x-govuk/govuk-prototype-components": "^3.0.9",
-        "accessible-autocomplete": "^2.0.3",
-        "classnames": "^2.2.6",
-        "date-fns": "^3.6.0",
-        "diff": "^4.0.1",
-        "govuk-frontend": "^5.8.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.4",
-        "mustache": "^3.0.1",
-        "qs": "^6.6.1",
-        "react": "^16.9.0",
-        "react-markdown": "^6.0.2",
-        "react-redux": "^7.1.0",
-        "redux": "^4.0.1",
-        "remark-breaks": "^2.0.2",
-        "shasum": "^1.0.2",
-        "url": "^0.11.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
-      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      },
-      "engines": {
-        "npm": ">=1.4.0"
-      }
+      "resolved": "packages/asl-components",
+      "link": true
     },
     "node_modules/@ukhomeoffice/asl-constants": {
-      "version": "2.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
-      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
-      "license": "MIT"
+      "resolved": "packages/asl-constants",
+      "link": true
     },
     "node_modules/@ukhomeoffice/asl-dictionary": {
-      "version": "2.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-dictionary/2.1.0/681a630147a8a983861f66ff316540dbbf563ba0",
-      "integrity": "sha512-bhi2L8RMu5AGjVTpYc05o6xYV5oHbdrTiTC4z0RCtpqJ/HWjufw+cD8+hvMG8579uYIaJwqC41E0pChrStU1nQ==",
-      "license": "MIT"
+      "resolved": "packages/asl-dictionary",
+      "link": true
     },
     "node_modules/@ukhomeoffice/asl-slate-edit-list": {
       "version": "0.0.8",
@@ -5357,6 +5159,38 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-jest": {
@@ -6583,9 +6417,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "134.0.5",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-134.0.5.tgz",
-      "integrity": "sha512-edXbiuShAvH6Elx8Hobl4NQkgNRMIozcW7ZlEiE8TBynZHRazrepO9hfftQzZgztPvjMQiSWeWjZaDV3SecYaw==",
+      "version": "135.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-135.0.0.tgz",
+      "integrity": "sha512-ilE3cIrIieiRU/a6MNpt0CL0UZs2tu0lQAes+el5SV03MB1zYIEXy+dDeueid/g8AmT1loy7TB2fjWwcHLY8lg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -12859,18 +12693,16 @@
       }
     },
     "node_modules/keycloak-connect": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
-      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-7.0.1.tgz",
+      "integrity": "sha512-JC5IPlm6TbWfK7xrD/Ef3QQRvuldR2teudbdKCTHo1+NcVmSlKVUeip2drttjUo/JUpQ1DjfpdZB/xMfqnEv5g==",
+      "deprecated": "This package is deprecated and will be removed in the future. We will shortly provide more details on removal date, and recommended alternatives.",
       "license": "Apache-2.0",
       "dependencies": {
         "jwk-to-pem": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "optionalDependencies": {
-        "chromedriver": "latest"
+        "node": ">=4.6.2"
       }
     },
     "node_modules/keyv": {
@@ -21008,7 +20840,8 @@
       }
     },
     "packages/asl": {
-      "version": "2.0.3",
+      "version": "2.0.4",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@asl/pages": "file:../asl-pages",
@@ -21048,7 +20881,7 @@
       }
     },
     "packages/asl-attachments": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -21065,8 +20898,231 @@
         "eslint": "^8.32.0"
       }
     },
+    "packages/asl-attachments/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-attachments/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-attachments/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-attachments/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
+    "packages/asl-attachments/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-attachments/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-attachments/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
+    "packages/asl-attachments/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-components": {
+      "name": "@ukhomeoffice/asl-components",
+      "version": "13.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.0",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "enzyme": "^3.11.0",
+        "enzyme-adapter-react-16": "^1.15.2",
+        "eslint": "^8.23.1",
+        "eslint-plugin-react": "^7.32.2",
+        "jest": "^29.3.1",
+        "react-dom": "^16.5.2"
+      }
+    },
+    "packages/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-constants": {
+      "name": "@ukhomeoffice/asl-constants",
+      "version": "2.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^8.40.0"
+      }
+    },
     "packages/asl-data-exports": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -21092,6 +21148,67 @@
         "mocha": "^9.2.0",
         "nodemon": "^2.0.7",
         "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-data-exports/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
       }
     },
     "packages/asl-data-exports/node_modules/@babel/code-frame": {
@@ -21149,6 +21266,53 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "packages/asl-data-exports/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-data-exports/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-data-exports/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
     "packages/asl-data-exports/node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -21170,6 +21334,15 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "packages/asl-data-exports/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "packages/asl-data-exports/node_modules/dotenv": {
@@ -21339,6 +21512,18 @@
         "node": ">=4"
       }
     },
+    "packages/asl-data-exports/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
     "packages/asl-data-exports/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -21361,6 +21546,33 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/asl-data-exports/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
+    "packages/asl-data-exports/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "packages/asl-data-exports/node_modules/nodemon": {
@@ -21468,6 +21680,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/asl-dictionary": {
+      "name": "@ukhomeoffice/asl-dictionary",
+      "version": "2.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^8.27.0"
+      }
+    },
     "packages/asl-emailer": {
       "version": "1.1.1",
       "license": "MIT",
@@ -21484,6 +21704,135 @@
         "nodemon": "^3.1.9",
         "sinon": "^19.0.2"
       }
+    },
+    "packages/asl-emailer/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-emailer/node_modules/@asl/service/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-emailer/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-emailer/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-emailer/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-emailer/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-emailer/node_modules/acorn": {
       "version": "6.4.2",
@@ -21833,6 +22182,18 @@
         "node": ">=4"
       }
     },
+    "packages/asl-emailer/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
     "packages/asl-emailer/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -21851,6 +22212,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "packages/asl-emailer/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
       }
     },
     "packages/asl-emailer/node_modules/levn": {
@@ -22190,7 +22566,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-internal-api": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -22220,6 +22596,166 @@
         "supertest": "^6.1.3",
         "uuid": "^8.3.2"
       }
+    },
+    "packages/asl-internal-api/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@asl/service/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@asl/service/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@asl/service/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-internal-api/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-internal-api/node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -22276,6 +22812,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-internal-api/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-internal-api/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
       }
     },
     "packages/asl-internal-api/node_modules/minimatch": {
@@ -22337,6 +22900,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "packages/asl-internal-api/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
     "packages/asl-internal-api/node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -22355,7 +22930,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-internal-ui": {
-      "version": "3.7.3",
+      "version": "3.7.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -22408,11 +22983,226 @@
         "webpack-cli": "^4.9.2"
       }
     },
+    "packages/asl-internal-ui/node_modules/@asl/projects": {
+      "version": "15.10.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-15.10.4.tgz",
+      "integrity": "sha512-i9xcBNtLEkVvoD3qWkRdoas5xxJpKESt4tk+cIgiokGijP+4Qiw65S8rMkp1h0HkWKiuzMuFabQ5XfcC2W+Ibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asl/service": "^11.0.4",
+        "@asl/slate-edit-table": "0.0.3",
+        "@babel/core": "^7.24.4",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "details-element-polyfill": "^2.3.0",
+        "docx": "5.0.0-rc4",
+        "fast-array-diff": "^1.1.0",
+        "file-saver": "^2.0.0",
+        "immutable": "^3.8.2",
+        "is-hotkey": "^0.2.0",
+        "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mdn-polyfills": "^5.15.0",
+        "minimatch": "^3.0.4",
+        "react": "^16.9.0",
+        "react-dom": "^16.6.0",
+        "react-icons-kit": "^1.1.6",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "react-router": "^5.1.2",
+        "react-router-dom": "^5.0.1",
+        "react-router-hash-link": "^1.2.1",
+        "react-transition-group": "^1.2.1",
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-parse": "^9.0.0",
+        "sha.js": "^2.4.11",
+        "shasum": "^1.0.2",
+        "slate": "^0.47.8",
+        "slate-react": "^0.22.10",
+        "unified": "^9.2.2",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/@asl/slate-edit-table": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
+      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "slate-schema-violations": "^0.1.39"
+      },
+      "peerDependencies": {
+        "immutable": "^3.8.2",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
+    "packages/asl-internal-ui/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-internal-ui/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "packages/asl-internal-ui/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "packages/asl-internal-ui/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
     },
     "packages/asl-internal-ui/node_modules/mustache": {
       "version": "2.3.2",
@@ -22511,7 +23301,7 @@
       }
     },
     "packages/asl-metrics": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "^15.10.4",
@@ -22543,6 +23333,250 @@
         "sinon": "^19.0.2",
         "uuid": "^8.1.0"
       }
+    },
+    "packages/asl-metrics/node_modules/@asl/projects": {
+      "version": "15.10.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-15.10.4.tgz",
+      "integrity": "sha512-i9xcBNtLEkVvoD3qWkRdoas5xxJpKESt4tk+cIgiokGijP+4Qiw65S8rMkp1h0HkWKiuzMuFabQ5XfcC2W+Ibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asl/service": "^11.0.4",
+        "@asl/slate-edit-table": "0.0.3",
+        "@babel/core": "^7.24.4",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "details-element-polyfill": "^2.3.0",
+        "docx": "5.0.0-rc4",
+        "fast-array-diff": "^1.1.0",
+        "file-saver": "^2.0.0",
+        "immutable": "^3.8.2",
+        "is-hotkey": "^0.2.0",
+        "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mdn-polyfills": "^5.15.0",
+        "minimatch": "^3.0.4",
+        "react": "^16.9.0",
+        "react-dom": "^16.6.0",
+        "react-icons-kit": "^1.1.6",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "react-router": "^5.1.2",
+        "react-router-dom": "^5.0.1",
+        "react-router-hash-link": "^1.2.1",
+        "react-transition-group": "^1.2.1",
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-parse": "^9.0.0",
+        "sha.js": "^2.4.11",
+        "shasum": "^1.0.2",
+        "slate": "^0.47.8",
+        "slate-react": "^0.22.10",
+        "unified": "^9.2.2",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/projects/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/projects/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/service/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/service/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/service/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/asl-metrics/node_modules/@asl/slate-edit-table": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
+      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "slate-schema-violations": "^0.1.39"
+      },
+      "peerDependencies": {
+        "immutable": "^3.8.2",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
+      }
+    },
+    "packages/asl-metrics/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-metrics/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-metrics/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-metrics/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-metrics/node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -22611,6 +23645,42 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/asl-metrics/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-metrics/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/asl-metrics/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
     "packages/asl-metrics/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -22670,6 +23740,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "packages/asl-metrics/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
     "packages/asl-metrics/node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -22698,7 +23780,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-notifications": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -22724,6 +23806,147 @@
         "nodemon": "^3.1.9",
         "pg": "^8.7.3"
       }
+    },
+    "packages/asl-notifications/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-notifications/node_modules/@asl/service/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-notifications/node_modules/@asl/service/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-notifications/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-notifications/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-notifications/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-notifications/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-notifications/node_modules/acorn": {
       "version": "6.4.2",
@@ -23093,6 +24316,21 @@
         "node": ">=4"
       }
     },
+    "packages/asl-notifications/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
     "packages/asl-notifications/node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -23432,6 +24670,7 @@
     "packages/asl-pages": {
       "name": "@asl/pages",
       "version": "31.10.4",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "^15.10.4",
@@ -23500,6 +24739,221 @@
         "sinon": "^19.0.2"
       }
     },
+    "packages/asl-pages/node_modules/@asl/projects": {
+      "version": "15.10.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-15.10.4.tgz",
+      "integrity": "sha512-i9xcBNtLEkVvoD3qWkRdoas5xxJpKESt4tk+cIgiokGijP+4Qiw65S8rMkp1h0HkWKiuzMuFabQ5XfcC2W+Ibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asl/service": "^11.0.4",
+        "@asl/slate-edit-table": "0.0.3",
+        "@babel/core": "^7.24.4",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "details-element-polyfill": "^2.3.0",
+        "docx": "5.0.0-rc4",
+        "fast-array-diff": "^1.1.0",
+        "file-saver": "^2.0.0",
+        "immutable": "^3.8.2",
+        "is-hotkey": "^0.2.0",
+        "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mdn-polyfills": "^5.15.0",
+        "minimatch": "^3.0.4",
+        "react": "^16.9.0",
+        "react-dom": "^16.6.0",
+        "react-icons-kit": "^1.1.6",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "react-router": "^5.1.2",
+        "react-router-dom": "^5.0.1",
+        "react-router-hash-link": "^1.2.1",
+        "react-transition-group": "^1.2.1",
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-parse": "^9.0.0",
+        "sha.js": "^2.4.11",
+        "shasum": "^1.0.2",
+        "slate": "^0.47.8",
+        "slate-react": "^0.22.10",
+        "unified": "^9.2.2",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-pages/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-pages/node_modules/@asl/slate-edit-table": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
+      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "slate-schema-violations": "^0.1.39"
+      },
+      "peerDependencies": {
+        "immutable": "^3.8.2",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
+      }
+    },
+    "packages/asl-pages/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-pages/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-pages/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-pages/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
+    "packages/asl-pages/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-pages/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/asl-pages/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
     "packages/asl-pages/node_modules/moment-business-time": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/moment-business-time/-/moment-business-time-0.7.1.tgz",
@@ -23523,7 +24977,7 @@
       }
     },
     "packages/asl-permissions": {
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -23548,6 +25002,141 @@
         "sinon": "^19.0.2",
         "supertest": "^3.1.0"
       }
+    },
+    "packages/asl-permissions/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-permissions/node_modules/@asl/service/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-permissions/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-permissions/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-permissions/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-permissions/node_modules/@ukhomeoffice/asl-components/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-permissions/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-permissions/node_modules/acorn": {
       "version": "6.4.2",
@@ -23925,6 +25514,18 @@
         "node": ">=4"
       }
     },
+    "packages/asl-permissions/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
     "packages/asl-permissions/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -23951,6 +25552,21 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/asl-permissions/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
     },
     "packages/asl-permissions/node_modules/levn": {
       "version": "0.3.0",
@@ -24060,6 +25676,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/asl-permissions/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "packages/asl-permissions/node_modules/optionator": {
@@ -24384,8 +26012,761 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "packages/asl-projects": {
+      "name": "@asl/projects",
+      "version": "15.10.1",
+      "license": "MIT",
+      "dependencies": {
+        "@asl/service": "^11.0.1",
+        "@asl/slate-edit-table": "0.0.3",
+        "@babel/core": "^7.24.4",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.1",
+        "@ukhomeoffice/asl-constants": "^2.2.0",
+        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "details-element-polyfill": "^2.3.0",
+        "docx": "5.0.0-rc4",
+        "fast-array-diff": "^1.1.0",
+        "file-saver": "^2.0.0",
+        "immutable": "^3.8.2",
+        "is-hotkey": "^0.2.0",
+        "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mdn-polyfills": "^5.15.0",
+        "minimatch": "^3.0.4",
+        "react": "^16.9.0",
+        "react-dom": "^16.6.0",
+        "react-icons-kit": "^1.1.6",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "react-router": "^5.1.2",
+        "react-router-dom": "^5.0.1",
+        "react-router-hash-link": "^1.2.1",
+        "react-transition-group": "^1.2.1",
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-parse": "^9.0.0",
+        "sha.js": "^2.4.11",
+        "shasum": "^1.0.2",
+        "slate": "^0.47.8",
+        "slate-react": "^0.22.10",
+        "unified": "^9.2.2",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "@babel/register": "^7.8.3",
+        "@ukhomeoffice/eslint-config-asl": "^3.0.0",
+        "babel-eslint": "^10.0.1",
+        "eslint": "^7.32.0",
+        "eslint-plugin-import": "^2.29.1",
+        "mocha": "^11.1.0",
+        "sinon": "19.0.2"
+      }
+    },
+    "packages/asl-projects/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-projects/node_modules/@asl/service/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-projects/node_modules/@asl/service/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-projects/node_modules/@asl/service/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-projects/node_modules/@asl/slate-edit-table": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
+      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "slate-schema-violations": "^0.1.39"
+      },
+      "peerDependencies": {
+        "immutable": "^3.8.2",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
+      }
+    },
+    "packages/asl-projects/node_modules/@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "packages/asl-projects/node_modules/@eslint/eslintrc": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "packages/asl-projects/node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/asl-projects/node_modules/@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "packages/asl-projects/node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "packages/asl-projects/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "packages/asl-projects/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.1/02150810d650f014a69956292dd76eea58feb8d4",
+      "integrity": "sha512-8yoEun4qgQdgjaUlcSbEEBVprdQeqtPV1KSkHF3iqopB7XFwqVDW6g7VaG45kXWMVQVIhDOAa79u5HUOUKaEbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.0",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-projects/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-projects/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-projects/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
+    "packages/asl-projects/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "packages/asl-projects/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/asl-projects/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "packages/asl-projects/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/asl-projects/node_modules/eslint": {
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.9",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/asl-projects/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/asl-projects/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/asl-projects/node_modules/eslint/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/asl-projects/node_modules/espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "packages/asl-projects/node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/asl-projects/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "packages/asl-projects/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/asl-projects/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/asl-projects/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-projects/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/asl-projects/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/asl-projects/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
+    "packages/asl-projects/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/asl-projects/node_modules/mocha": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
+      "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/asl-projects/node_modules/mocha/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-projects/node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-projects/node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/asl-projects/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-projects/node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "packages/asl-projects/node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "packages/asl-projects/node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-projects/node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/asl-projects/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "packages/asl-projects/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/asl-projects/node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "packages/asl-public-api": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -24417,6 +26798,206 @@
         "supertest": "^3.4.2",
         "uuid": "^3.4.0"
       }
+    },
+    "packages/asl-public-api/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-public-api/node_modules/@asl/service/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/asl-public-api/node_modules/@asl/service/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-public-api/node_modules/@asl/service/node_modules/into-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-4.0.0.tgz",
+      "integrity": "sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==",
+      "license": "MIT",
+      "dependencies": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/asl-public-api/node_modules/@asl/service/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/asl-public-api/node_modules/@asl/service/node_modules/p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/asl-public-api/node_modules/@asl/service/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-public-api/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-public-api/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-public-api/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-public-api/node_modules/@ukhomeoffice/asl-components/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-public-api/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-public-api/node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -24503,6 +27084,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/asl-public-api/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
     "packages/asl-public-api/node_modules/into-stream": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
@@ -24525,6 +27118,21 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/asl-public-api/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
     },
     "packages/asl-public-api/node_modules/minimatch": {
       "version": "5.1.6",
@@ -24583,6 +27191,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/asl-public-api/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "packages/asl-public-api/node_modules/p-is-promise": {
@@ -24727,7 +27347,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-resolver": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -24759,6 +27379,340 @@
         "nyc": "^17.1.0",
         "sinon": "^19.0.2"
       }
+    },
+    "packages/asl-resolver/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/aws-sdk": {
+      "version": "2.1692.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
+      "integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/aws-sdk/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/aws-sdk/node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/buffer/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/@asl/service/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-components/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-components/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-components/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-resolver/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-resolver/node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -24885,6 +27839,21 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "packages/asl-resolver/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
     "packages/asl-resolver/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -24942,6 +27911,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "packages/asl-resolver/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "packages/asl-resolver/node_modules/punycode": {
@@ -25007,7 +27988,7 @@
     },
     "packages/asl-schema": {
       "name": "@asl/schema",
-      "version": "11.1.4",
+      "version": "11.2.0",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "^2.2.1",
@@ -25066,6 +28047,12 @@
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
       }
+    },
+    "packages/asl-schema/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-schema/node_modules/acorn": {
       "version": "6.4.2",
@@ -26323,7 +29310,7 @@
       }
     },
     "packages/asl-search": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@acuris/aws-es-connection": "^2.1.0",
@@ -26352,6 +29339,147 @@
         "dotenv": "^8.2.0",
         "eslint": "^7.3.1",
         "nodemon": "^3.1.9"
+      }
+    },
+    "packages/asl-search/node_modules/@asl/projects": {
+      "version": "15.10.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-15.10.4.tgz",
+      "integrity": "sha512-i9xcBNtLEkVvoD3qWkRdoas5xxJpKESt4tk+cIgiokGijP+4Qiw65S8rMkp1h0HkWKiuzMuFabQ5XfcC2W+Ibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asl/service": "^11.0.4",
+        "@asl/slate-edit-table": "0.0.3",
+        "@babel/core": "^7.24.4",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "details-element-polyfill": "^2.3.0",
+        "docx": "5.0.0-rc4",
+        "fast-array-diff": "^1.1.0",
+        "file-saver": "^2.0.0",
+        "immutable": "^3.8.2",
+        "is-hotkey": "^0.2.0",
+        "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mdn-polyfills": "^5.15.0",
+        "minimatch": "^3.0.4",
+        "react": "^16.9.0",
+        "react-dom": "^16.6.0",
+        "react-icons-kit": "^1.1.6",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "react-router": "^5.1.2",
+        "react-router-dom": "^5.0.1",
+        "react-router-hash-link": "^1.2.1",
+        "react-transition-group": "^1.2.1",
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-parse": "^9.0.0",
+        "sha.js": "^2.4.11",
+        "shasum": "^1.0.2",
+        "slate": "^0.47.8",
+        "slate-react": "^0.22.10",
+        "unified": "^9.2.2",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-search/node_modules/@asl/projects/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-search/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-search/node_modules/@asl/service/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-search/node_modules/@asl/slate-edit-table": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
+      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "slate-schema-violations": "^0.1.39"
+      },
+      "peerDependencies": {
+        "immutable": "^3.8.2",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
       }
     },
     "packages/asl-search/node_modules/@babel/code-frame": {
@@ -26409,6 +29537,62 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "packages/asl-search/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-search/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-search/node_modules/@ukhomeoffice/asl-components/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-search/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
     "packages/asl-search/node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -26430,6 +29614,15 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "packages/asl-search/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "packages/asl-search/node_modules/dotenv": {
@@ -26589,6 +29782,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/asl-search/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
     "packages/asl-search/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -26597,6 +29802,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "packages/asl-search/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/asl-search/node_modules/js-yaml": {
@@ -26611,6 +29825,33 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/asl-search/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
+    "packages/asl-search/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "packages/asl-search/node_modules/sprintf-js": {
@@ -26641,6 +29882,432 @@
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "packages/asl-service": {
+      "name": "@asl/service",
+      "version": "10.5.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.5.0",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^7.0.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "devDependencies": {
+        "@ukhomeoffice/eslint-config-asl": "^3.0.0",
+        "eslint": "^8.26.0",
+        "mocha": "^10.4.0",
+        "sinon": "^6.1.5"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-service/node_modules/@sinonjs/commons": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "packages/asl-service/node_modules/@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "packages/asl-service/node_modules/@sinonjs/formatio/node_modules/@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "packages/asl-service/node_modules/@sinonjs/samsam": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
+      "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "packages/asl-service/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.5.0/3a2dbc35f0511193e5e2fc12398271e89234a853",
+      "integrity": "sha512-NauUA8/HaRgI2KD6SH3N82aATWmGtUet9fM7dqbOOW+pD8Hd27PFgKNBrhQVrZilV+c1Rzm/wPRhT6LPch45aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.1.5",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.0.0",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-service/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-service/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-service/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/asl-service/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/asl-service/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "packages/asl-service/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/asl-service/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl-service/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/asl-service/node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/asl-service/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/asl-service/node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "packages/asl-service/node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/asl-service/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-service/node_modules/nise": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^5.0.1",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "packages/asl-service/node_modules/nise/node_modules/lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "packages/asl-service/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "packages/asl-service/node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "packages/asl-service/node_modules/sinon": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+      "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
+      "deprecated": "16.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.2",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.7.5",
+        "nise": "^1.4.5",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "packages/asl-service/node_modules/sinon/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-service/node_modules/sinon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/asl-service/node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "packages/asl-service/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/asl-service/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/asl-taskflow": {
@@ -27028,7 +30695,7 @@
       }
     },
     "packages/asl-workflow": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -27060,6 +30727,288 @@
         "sinon": "^19.0.2",
         "supertest": "^3.3.0"
       }
+    },
+    "packages/asl-workflow/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/aws-sdk": {
+      "version": "2.1692.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
+      "integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/aws-sdk/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/aws-sdk/node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/buffer/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-workflow/node_modules/@asl/service/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-components/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-components/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-components/node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-components/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/asl-workflow/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
     },
     "packages/asl-workflow/node_modules/acorn": {
       "version": "6.4.2",
@@ -27552,6 +31501,18 @@
         "node": ">=4"
       }
     },
+    "packages/asl-workflow/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
     "packages/asl-workflow/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -27602,6 +31563,21 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "packages/asl-workflow/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
       }
     },
     "packages/asl-workflow/node_modules/levn": {
@@ -27751,6 +31727,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/asl-workflow/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
       }
     },
     "packages/asl-workflow/node_modules/nyc": {
@@ -28408,6 +32396,233 @@
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "packages/asl/node_modules/@asl/projects": {
+      "version": "15.10.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/projects/-/@asl/projects-15.10.4.tgz",
+      "integrity": "sha512-i9xcBNtLEkVvoD3qWkRdoas5xxJpKESt4tk+cIgiokGijP+4Qiw65S8rMkp1h0HkWKiuzMuFabQ5XfcC2W+Ibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asl/service": "^11.0.4",
+        "@asl/slate-edit-table": "0.0.3",
+        "@babel/core": "^7.24.4",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-slate-edit-list": "0.0.8",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "@ukhomeoffice/react-components": "^1.3.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "details-element-polyfill": "^2.3.0",
+        "docx": "5.0.0-rc4",
+        "fast-array-diff": "^1.1.0",
+        "file-saver": "^2.0.0",
+        "immutable": "^3.8.2",
+        "is-hotkey": "^0.2.0",
+        "jsondiffpatch": "^0.4.1",
+        "jsonpath-plus": "^10.0.1",
+        "lodash": "^4.17.21",
+        "mdn-polyfills": "^5.15.0",
+        "minimatch": "^3.0.4",
+        "react": "^16.9.0",
+        "react-dom": "^16.6.0",
+        "react-icons-kit": "^1.1.6",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "react-router": "^5.1.2",
+        "react-router-dom": "^5.0.1",
+        "react-router-hash-link": "^1.2.1",
+        "react-transition-group": "^1.2.1",
+        "redux": "^4.0.1",
+        "redux-thunk": "^2.3.0",
+        "remark-parse": "^9.0.0",
+        "sha.js": "^2.4.11",
+        "shasum": "^1.0.2",
+        "slate": "^0.47.8",
+        "slate-react": "^0.22.10",
+        "unified": "^9.2.2",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl/node_modules/@asl/service": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-11.0.4.tgz",
+      "integrity": "sha512-mKc40Jiyc6yewAXlM8wV6B00QBDyb76bPiM6E2MpeDylmvpXrnHmDzoqmCUVGM5+Q/emnGmtVTB0GqWmmu0JzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "@lennym/redis-session": "^2.2.0",
+        "@redux-devtools/extension": "^3.3.0",
+        "@ukhomeoffice/asl-components": "13.9.5",
+        "@ukhomeoffice/frontend-toolkit": "^3.0.0",
+        "aws-sdk": "^2.1370.0",
+        "babel-plugin-transform-require-ignore": "^0.1.1",
+        "body-parser": "^1.18.3",
+        "buffer": "^6.0.3",
+        "express": "^4.16.2",
+        "express-react-views": "^0.11.0",
+        "express-session": "^1.15.6",
+        "find-root": "^1.1.0",
+        "glob": "^7.1.2",
+        "helmet": "^3.21.1",
+        "helmet-csp": "^2.9.3",
+        "hot-shots": "^6.8.2",
+        "http-proxy": "^1.18.1",
+        "into-stream": "^4.0.0",
+        "js-base64": "^2.5.1",
+        "keycloak-connect": "^26.1.1",
+        "lodash": "^4.17.21",
+        "mkdirp": "^0.5.1",
+        "moment": "^2.29.4",
+        "morgan": "^1.9.1",
+        "mustache": "^2.3.2",
+        "on-finished": "^2.3.0",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "prop-types": "^15.8.1",
+        "qs": "^6.5.2",
+        "r2": "^2.0.1",
+        "react": "^16.9.0",
+        "react-dom": "^16.4.2",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.0",
+        "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.3.0",
+        "set-immediate-shim": "^2.0.0",
+        "terser-webpack-plugin": "^4.2.3",
+        "url": "^0.11.0",
+        "url-search-params": "^1.1.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^5.69.1"
+      }
+    },
+    "packages/asl/node_modules/@asl/slate-edit-table": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/slate-edit-table/-/@asl/slate-edit-table-0.0.3.tgz",
+      "integrity": "sha512-8vtWS4Ft288RhQcxD1IU0VtLQzNzUXzzhyWsH+QZ8jJ5jHz2UUG59NXOeZ8l1l2pHap5ubGKig1RZ8Tqz8YFbg==",
+      "license": "MIT",
+      "dependencies": {
+        "slate-schema-violations": "^0.1.39"
+      },
+      "peerDependencies": {
+        "immutable": "^3.8.2",
+        "slate": "^0.47.4",
+        "slate-react": "^0.22.4"
+      }
+    },
+    "packages/asl/node_modules/@ukhomeoffice/asl-components": {
+      "version": "13.9.5",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-components/13.9.5/f61edbd19c6425d186ea0d8ed990ccca281aba59",
+      "integrity": "sha512-UOSL4HtPWwjo8KNmOxSaBAYNobYoaRYC1Z9Wz+oAybe6sATeNICxv6KGlv+ioPihQ3nKSSC3YzzxR9i3MllJKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ukhomeoffice/asl-constants": "^2.2.1",
+        "@ukhomeoffice/asl-dictionary": "^2.1.0",
+        "@ukhomeoffice/react-components": "^1.4.2",
+        "@x-govuk/govuk-prototype-components": "^3.0.9",
+        "accessible-autocomplete": "^2.0.3",
+        "classnames": "^2.2.6",
+        "date-fns": "^3.6.0",
+        "diff": "^4.0.1",
+        "govuk-frontend": "^5.8.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "mustache": "^3.0.1",
+        "qs": "^6.6.1",
+        "react": "^16.9.0",
+        "react-markdown": "^6.0.2",
+        "react-redux": "^7.1.0",
+        "redux": "^4.0.1",
+        "remark-breaks": "^2.0.2",
+        "shasum": "^1.0.2",
+        "url": "^0.11.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "packages/asl/node_modules/@ukhomeoffice/asl-components/node_modules/mustache": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
+      "integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "packages/asl/node_modules/@ukhomeoffice/asl-constants": {
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@ukhomeoffice/asl-constants/2.2.1/f1384720f213f36a2af83d4a4d8f6e26b52139cd",
+      "integrity": "sha512-y3bW21JMzTtGVp1Fac2ErNsDFKfIA4igaCX8BEW9iYPV1Ttzox9Cehi4feAejSNNWAS/IffEf+4qIeTkUPNVug==",
+      "license": "MIT"
+    },
+    "packages/asl/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "packages/asl/node_modules/hot-shots": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.8.7.tgz",
+      "integrity": "sha512-XH8iezBSZgVw2jegu96pUfF1Zv0VZ/iXjb7L5yE3F7mn7/bdhf4qeniXjO0wQWeefe433rhOsazNKLxM+XMI9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.0.x"
+      }
+    },
+    "packages/asl/node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/asl/node_modules/keycloak-connect": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
+      }
+    },
+    "packages/asl/node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
     }
   }
 }

--- a/packages/asl-schema/package.json
+++ b/packages/asl-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asl/schema",
-  "version": "11.1.5",
+  "version": "11.2.0",
   "description": "Sequelize schema for licensing models",
   "main": "index.js",
   "scripts": {

--- a/packages/asl-schema/schema/project.js
+++ b/packages/asl-schema/schema/project.js
@@ -98,13 +98,6 @@ class ProjectQueryBuilder extends QueryBuilder {
         builder
           .where('projects.status', 'active')
           .orWhere((qb) => {
-            qb.where('projects.status', 'transferred').where(
-              'projects.transferredOutDate',
-              '>=',
-              `${year}-12-31`
-            );
-          })
-          .orWhere((qb) => {
             qb.where('projects.status', 'expired').where(
               'projects.expiryDate',
               '>=',

--- a/packages/asl-schema/test/functional/project.js
+++ b/packages/asl-schema/test/functional/project.js
@@ -666,14 +666,14 @@ describe('Project model', () => {
         });
     });
 
-    it('does include projects transferred out after the end of the year', () => {
+    it('does not include projects transferred out after the end of the year', () => {
       return Promise.resolve()
         .then(() => this.models.Project.query().whereRopsDue(2020))
         .then(projects => {
           return projects.map(project => project.id);
         })
         .then(projectIds => {
-          assert.ok(projectIds.includes(ids.transferOut));
+          assert.ok(!projectIds.includes(ids.transferOut));
         });
     });
 


### PR DESCRIPTION
`whereRopsDue` is a function which is used in multiple places to derive rops data. removed the where clause on transferred rops so those are excluded from the establishment as the project is transferred so we don't want to count rops which are transferred from an establishment. 

This change will remove the rops alert as the transferred rops are not returned. 