### PR TITLE
Fix projects version import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23398,6 +23398,7 @@
     "packages/asl-pages": {
       "name": "@asl/pages",
       "version": "31.10.4",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "file:../asl-projects",

--- a/packages/asl-pages/pages/project-version/update/router.js
+++ b/packages/asl-pages/pages/project-version/update/router.js
@@ -1,5 +1,5 @@
 const { page } = require('@asl/service/ui');
-const { dependencies } = require('../../../package.json');
+const projectsVersion = require('@asl/projects/package.json').version;
 const bodyParser = require('body-parser');
 const semver = require('semver');
 const { get } = require('lodash');
@@ -86,8 +86,7 @@ module.exports = settings => {
 
   app.put('/', (req, res, next) => {
     const clientVersion = req.get('x-projects-version');
-    const requiredVersion = dependencies['@asl/projects'];
-    if (semver.diff(clientVersion, semver.minVersion(requiredVersion)) === 'major') {
+    if (semver.diff(clientVersion, semver.minVersion(projectsVersion)) === 'major') {
       res.status(400);
       return res.json({ message: 'Update required', code: 'UPDATE_REQUIRED' });
     }


### PR DESCRIPTION
Read projects version from the node module rather than the `package.json` file, since the latter now just points to a file path which is incompatible with `semver`.