### PR TITLE
whereRopsdue custom query not to inlcude tranfered.

### DIFF
--- a/packages/asl-schema/schema/project.js
+++ b/packages/asl-schema/schema/project.js
@@ -98,13 +98,6 @@ class ProjectQueryBuilder extends QueryBuilder {
         builder
           .where('projects.status', 'active')
           .orWhere((qb) => {
-            qb.where('projects.status', 'transferred').where(
-              'projects.transferredOutDate',
-              '>=',
-              `${year}-12-31`
-            );
-          })
-          .orWhere((qb) => {
             qb.where('projects.status', 'expired').where(
               'projects.expiryDate',
               '>=',

--- a/packages/asl-schema/test/functional/project.js
+++ b/packages/asl-schema/test/functional/project.js
@@ -666,14 +666,14 @@ describe('Project model', () => {
         });
     });
 
-    it('does include projects transferred out after the end of the year', () => {
+    it('does not include projects transferred out after the end of the year', () => {
       return Promise.resolve()
         .then(() => this.models.Project.query().whereRopsDue(2020))
         .then(projects => {
           return projects.map(project => project.id);
         })
         .then(projectIds => {
-          assert.ok(projectIds.includes(ids.transferOut));
+          assert.ok(!projectIds.includes(ids.transferOut));
         });
     });
 


### PR DESCRIPTION
asl-schema has a set of custom query functions. 
- One of the functions returns a list of ROPs including transferred ROPs, this filter has been removed so no ROPs will be returned where transferred. 