### PR TITLE
Update protocol locations when establishment name changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16671,6 +16671,7 @@
     },
     "node_modules/unix-dgram": {
       "version": "2.0.6",
+      "hasInstallScript": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -17575,7 +17576,7 @@
       }
     },
     "packages/asl": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17616,7 +17617,7 @@
       }
     },
     "packages/asl-attachments": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -17703,7 +17704,7 @@
       }
     },
     "packages/asl-data-exports": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -18114,7 +18115,7 @@
       }
     },
     "packages/asl-emailer": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "file:../asl-service",
@@ -18835,7 +18836,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-internal-api": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -19000,7 +19001,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-internal-ui": {
-      "version": "3.7.4",
+      "version": "3.7.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19156,7 +19157,7 @@
       }
     },
     "packages/asl-metrics": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "file:../asl-projects",
@@ -19343,7 +19344,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-notifications": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -20076,7 +20077,7 @@
     },
     "packages/asl-pages": {
       "name": "@asl/pages",
-      "version": "31.10.4",
+      "version": "31.10.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20169,7 +20170,7 @@
       }
     },
     "packages/asl-permissions": {
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -21032,7 +21033,7 @@
     },
     "packages/asl-projects": {
       "name": "@asl/projects",
-      "version": "15.10.4",
+      "version": "15.10.5",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "file:../asl-service",
@@ -21578,7 +21579,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-public-api": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -21920,7 +21921,7 @@
       "license": "Apache-2.0"
     },
     "packages/asl-resolver": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -22200,7 +22201,7 @@
     },
     "packages/asl-schema": {
       "name": "@asl/schema",
-      "version": "11.1.5",
+      "version": "11.1.6",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "file:../asl-constants",
@@ -23516,7 +23517,7 @@
       }
     },
     "packages/asl-search": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@acuris/aws-es-connection": "^2.1.0",
@@ -23838,7 +23839,7 @@
     },
     "packages/asl-service": {
       "name": "@asl/service",
-      "version": "11.0.4",
+      "version": "11.0.5",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
@@ -24064,7 +24065,7 @@
     },
     "packages/asl-taskflow": {
       "name": "@ukhomeoffice/asl-taskflow",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.18.3",
@@ -24418,7 +24419,7 @@
       }
     },
     "packages/asl-toolbox": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -24447,7 +24448,7 @@
       }
     },
     "packages/asl-workflow": {
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",

--- a/packages/asl-resolver/.eslintrc.yml
+++ b/packages/asl-resolver/.eslintrc.yml
@@ -4,6 +4,9 @@ extends:
 plugins:
   - eslint-plugin-undocumented-env
 
+parserOptions:
+  ecmaVersion: 2020
+
 rules:
   undocumented-env/no-undocumented: 2
   indent: 0

--- a/packages/asl-resolver/lib/resolvers/establishment.js
+++ b/packages/asl-resolver/lib/resolvers/establishment.js
@@ -2,10 +2,51 @@ const resolver = require('./base-resolver');
 const { get, pick, omit } = require('lodash');
 const { generateLicenceNumber } = require('../utils');
 
+async function renameProtocolLocation(ProjectVersion, transaction, establishmentId, renameFrom, renameTo) {
+  // Find projects with availability at the renamed establishment (primary or additional), which contain the
+  // establishment in at least one protocol location.
+  const versionData = transaction.raw(
+    // language=PostgreSQL
+    `
+          SELECT pv.id, any_value(pv.data) as data
+          FROM projects p
+               LEFT JOIN project_versions pv ON p.id = pv.project_id
+               LEFT JOIN project_establishments pe ON p.id = pe.project_id
+               CROSS JOIN JSONB_ARRAY_ELEMENTS(pv.data -> 'protocols') WITH ORDINALITY AS proto(value, idx)
+               CROSS JOIN JSONB_ARRAY_ELEMENTS_TEXT(proto.value -> 'locations') WITH ORDINALITY AS location(value, idx)
+          WHERE (p.establishment_id = :establishmentId OR pe.establishment_id = :establishmentId)
+            AND location.value = :renameFrom
+          GROUP BY pv.id;
+    `,
+    {establishmentId, renameFrom}
+  ).stream();
+
+  const updates = [];
+
+  for await (const {id: versionId, data} of versionData) {
+    // Remove old and add new only where new establishment is a location, avoiding duplicates.
+    data.protocols.forEach(protocol => {
+      if (protocol.locations?.includes(renameFrom)) {
+        protocol.locations = [
+          ...new Set([
+            ...protocol.locations.filter(location => location !== renameFrom),
+            renameTo
+          ])
+        ];
+      }
+    });
+
+    updates.push(ProjectVersion.query(transaction).where({ id: versionId }).update({ data }));
+  }
+
+  await Promise.all(updates);
+}
+
 module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
-  const { Establishment, Authorisation, Reminder, Role } = models;
+  const { Establishment, Authorisation, Reminder, Role, ProjectVersion } = models;
 
   if (action === 'update') {
+    const existing = await Establishment.query(transaction).findById(id);
 
     let reminder;
     if (get(data, 'reminder')) {
@@ -59,6 +100,10 @@ module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
       await Role.query(transaction).where({ establishmentId: establishment.id, type: typeOfRoleToRemove }).delete();
     }
 
+    if (existing.name !== establishment.name) {
+      await renameProtocolLocation(ProjectVersion, transaction, id, existing.name, establishment.name);
+    }
+
     if (reminder) {
       await Reminder.upsert({
         ...reminder,
@@ -74,8 +119,6 @@ module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
 
   if (action === 'update-conditions') {
     const reminder = get(data, 'reminder');
-    data = pick(data, 'conditions');
-    action = 'update';
 
     if (reminder) {
       await Reminder.upsert({
@@ -86,11 +129,21 @@ module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
         deleted: reminder.deleted ? new Date().toISOString() : undefined
       }, undefined, transaction);
     }
+
+    return resolver(
+      {
+        Model: models.Establishment,
+        action: 'update',
+        data: pick(data, 'conditions'),
+        id
+      },
+      transaction
+    );
   }
 
   if (action === 'update-billing') {
-    data = { billing: { ...data, updatedAt: new Date().toISOString() } };
-    return Establishment.query(transaction).context({ preserveUpdatedAt: true }).patchAndFetchById(id, data);
+    const patch = { billing: { ...data, updatedAt: new Date().toISOString() } };
+    return Establishment.query(transaction).context({ preserveUpdatedAt: true }).patchAndFetchById(id, patch);
   }
 
   if (action === 'grant') {

--- a/packages/asl-resolver/test/helpers/assert-helpers.js
+++ b/packages/asl-resolver/test/helpers/assert-helpers.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+module.exports = {
+  /**
+   *
+   * @param {array} actual
+   * @param {array} expected
+   * @param {string | undefined} message
+   */
+  assertIncludesInAnyOrder(actual, expected, message = undefined) {
+    const messagePrefix = message ? `${message}: ` : '';
+
+    expected.forEach(entry => assert.ok(actual.includes(entry), `${messagePrefix}'${entry}' not present`));
+    assert.equal(actual.length, expected.length, `${messagePrefix}Lengths do not match`);
+  }
+};

--- a/packages/asl-resolver/test/resolvers/establishment.js
+++ b/packages/asl-resolver/test/resolvers/establishment.js
@@ -3,8 +3,9 @@ const moment = require('moment');
 const { establishment } = require('../../lib/resolvers');
 const db = require('../helpers/db');
 const { v4: uuid } = require('uuid');
+const { assertIncludesInAnyOrder } = require('../helpers/assert-helpers');
 
-const nowish = (a, b, n = 3) => {
+const nowish = (a, b = undefined, n = 3) => {
   const diff = moment(a).diff(b, 'seconds');
   return Math.abs(diff) < n;
 };
@@ -20,15 +21,17 @@ const reminder = {
   status: 'active'
 };
 
-const anEstablishment = ({
-  id = 8201,
-  name = 'University of Croydon',
-  updatedAt = '2019-01-01T10:38:43.666Z',
-  corporateStatus = 'non-profit',
-  legalName = undefined,
-  legalPhone = undefined,
-  legalEmail = undefined
-}) => {
+const anEstablishment = (
+  {
+    id = 8201,
+    name = 'University of Croydon',
+    updatedAt = '2019-01-01T10:38:43.666Z',
+    corporateStatus = 'non-profit',
+    legalName = undefined,
+    legalPhone = undefined,
+    legalEmail = undefined
+  }
+) => {
   return {
     id,
     name,
@@ -55,6 +58,65 @@ const aRole = ({ establishmentId = 8201, profileId, type }) => {
     profileId,
     type
   };
+};
+
+const insertProjectOfPrimaryEstablishment = async (models, {
+  establishmentId = 8201,
+  establishmentName = 'University of Croydon',
+  projectId,
+  versionIds
+}) => {
+  await models.Project.query().insert({
+    id: projectId,
+    establishmentId
+  });
+
+  for (const versionId of versionIds) {
+    await models.ProjectVersion.query().insert({
+      id: versionId,
+      projectId,
+      data: {
+        protocols: [
+          { locations: [establishmentName] },
+          { locations: ['POLE'] },
+          { locations: [establishmentName, 'POLE'] }
+        ]
+      }
+    });
+  }
+};
+
+const insertProjectWithAdditionalAvailability = async (models, {
+  primaryEstablishmentId = 8202,
+  primaryEstablishmentName = 'Marvell Pharmaceutical',
+  additionalAvailabilityId = 8201,
+  additionalAvailabilityName = 'University of Croydon',
+  projectId,
+  versionIds
+}) => {
+  await models.Project.query().insert({
+    id: projectId,
+    establishmentId: primaryEstablishmentId
+  });
+
+  await models.ProjectEstablishment.query().insert({
+    projectId,
+    establishmentId: additionalAvailabilityId
+  });
+
+  for (const versionId of versionIds) {
+    await models.ProjectVersion.query().insert({
+      id: versionId,
+      projectId,
+      data: {
+        protocols: [
+          { locations: [primaryEstablishmentName] },
+          { locations: [additionalAvailabilityName] },
+          { locations: [primaryEstablishmentName, additionalAvailabilityName] }
+        ]
+      }
+    });
+  }
 };
 
 describe('Establishment resolver', () => {
@@ -418,7 +480,12 @@ describe('Establishment resolver', () => {
     it('Replaces nprc and removes legal person details when switching from corporate to non-profit', () => {
       return Promise.resolve()
         .then(() => this.models.Establishment.query().insert([
-          anEstablishment({ corporateStatus: 'corporate', legalName: 'John Responsible', legalEmail: 'john@responsible.com', legalPhone: '01234 123456' })
+          anEstablishment({
+            corporateStatus: 'corporate',
+            legalName: 'John Responsible',
+            legalEmail: 'john@responsible.com',
+            legalPhone: '01234 123456'
+          })
         ]))
         .then(() => this.models.Profile.query().insert([
           aProfile(PROFILE_ID_1),
@@ -458,7 +525,12 @@ describe('Establishment resolver', () => {
     it('Replaces nprc and legal person details  when changed', () => {
       return Promise.resolve()
         .then(() => this.models.Establishment.query().insert([
-          anEstablishment({ corporateStatus: 'corporate', legalName: 'John Responsible', legalEmail: 'john@responsible.com', legalPhone: '01234 123456' })
+          anEstablishment({
+            corporateStatus: 'corporate',
+            legalName: 'John Responsible',
+            legalEmail: 'john@responsible.com',
+            legalPhone: '01234 123456'
+          })
         ]))
         .then(() => this.models.Profile.query().insert([
           aProfile(PROFILE_ID_1),
@@ -673,6 +745,93 @@ describe('Establishment resolver', () => {
       });
     });
 
+    describe('Updating establishment name', () => {
+      beforeEach(async () => {
+        await this.models.Establishment.query().insert([
+          {
+            id: 8202,
+            name: 'Marvell Pharmaceutical',
+            updatedAt: '2019-01-01T10:38:43.666Z'
+          }
+        ]);
+      });
+
+      it('renames protocol locations when renaming the primary establishment', async () => {
+        const projectId1 = '0ab141b8-417f-4399-8a25-82566de56902';
+        const project1Version1 = '21dbe1b5-0f00-47eb-aa76-e52bb51872c1';
+        const project1Version2 = '4f646f62-67c7-40b9-9f82-3dd89c57196f';
+
+        const projectId2 = '80be29e7-2a74-4f3d-a8a0-83ad87ad74cc';
+        const project2Version1 = '9638b89a-0810-4f81-95ea-5e28e8280869';
+
+        await insertProjectOfPrimaryEstablishment(
+          this.models,
+          {
+            projectId: projectId1,
+            versionIds: [project1Version1, project1Version2]
+          }
+        );
+
+        await insertProjectOfPrimaryEstablishment(
+          this.models,
+          {
+            projectId: projectId2,
+            versionIds: [project2Version1]
+          }
+        );
+
+        const opts = {
+          action: 'update',
+          id: 8201,
+          data: {
+            name: 'Renamed'
+          }
+        };
+
+        const transaction = await this.models.transaction();
+        await this.establishment(opts, transaction);
+        await transaction.commit();
+
+        for (const versionId of [project1Version1, project1Version2, project2Version1]) {
+          const { data } = await this.models.ProjectVersion.query().findById(versionId);
+
+          assert.deepEqual(data.protocols[0].locations, ['Renamed'], `ID: ${versionId}, primary location is unchanged`);
+          assert.deepEqual(data.protocols[1].locations, ['POLE'], `ID: ${versionId}, additional location is renamed`);
+          assertIncludesInAnyOrder(data.protocols[2].locations, ['Renamed', 'POLE'], `ID: ${versionId}`);
+        }
+      });
+
+      it('Renames protocol locations when an additionally available establishment is renamed', async () => {
+        const projectId = '957a791d-3f8c-47ac-956f-5261b15aefad';
+        const versionId = 'e765631c-3311-46bf-af3d-9562962a592f';
+
+        await insertProjectWithAdditionalAvailability(
+          this.models,
+          {
+            projectId,
+            versionIds: [versionId]
+          }
+        );
+
+        const opts = {
+          action: 'update',
+          id: 8201,
+          data: {
+            name: 'Renamed'
+          }
+        };
+
+        const transaction = await this.models.transaction();
+        await this.establishment(opts, transaction);
+        await transaction.commit();
+
+        const { data } = await this.models.ProjectVersion.query().findById(versionId);
+
+        assert.deepEqual(data.protocols[0].locations, ['Marvell Pharmaceutical'], `ID: ${versionId}, sole location is renamed`);
+        assert.deepEqual(data.protocols[1].locations, ['Renamed'], `ID: ${versionId}, other location is unchanged`);
+        assertIncludesInAnyOrder(data.protocols[2].locations, ['Renamed', 'Marvell Pharmaceutical'], `ID: ${versionId}`);
+      });
+    });
   });
 
 });

--- a/packages/asl-resolver/test/tasks/reset-billing.js
+++ b/packages/asl-resolver/test/tasks/reset-billing.js
@@ -73,8 +73,6 @@ describe('Annual reset of billing', () => {
     const [withBilling2] = await this.models.Establishment.query().where('id', UNI_WITH_BILLING_2.id);
     const [withoutBilling] = await this.models.Establishment.query().where('id', UNI_WITHOUT_BILLING.id);
 
-    console.log(withBilling1);
-
     assertAnnualFieldsRemoved(withBilling1, UNI_WITH_BILLING_1);
     assertAnnualFieldsRemoved(withBilling2, UNI_WITH_BILLING_2);
     assert.equal(withoutBilling.billing, null);


### PR DESCRIPTION
On granting an amendment to an establishment licence that includes changing the name, cascade that change to protocol location names in associated project licences

This re-applies the changes from https://github.com/UKHomeOffice/asl-resolver/pull/304