### PR TITLE
[ASL-4796] The error summary should include the renderContext in snippets

### DIFF
--- a/packages/asl-components/src/error-summary/index.jsx
+++ b/packages/asl-components/src/error-summary/index.jsx
@@ -4,7 +4,8 @@ import { connect } from 'react-redux';
 import { Snippet } from '../';
 
 const ErrorSummary = ({
-    errors
+    errors,
+    formatters = {}
 }) => {
     if (!size(errors)) {
         return null;
@@ -23,8 +24,16 @@ const ErrorSummary = ({
             <div className="govuk-error-summary__body">
                 <ul className="govuk-list govuk-error-summary__list">
                     {
-                        Object.keys(errors).map(key =>
-                            <li key={key}><a href={`#${key}`}><Snippet fallback={`errors.default.${errors[key]}`}>{`errors.${key}.${errors[key]}`}</Snippet></a></li>
+                        Object.keys(errors).map(key => {
+                            const snippetProps = formatters[key]?.renderContext ?? {};
+                            return <li key={key}>
+                                <a href={`#${key}`}>
+                                    <Snippet fallback={`errors.default.${errors[key]}`} {...snippetProps}>
+                                        {`errors.${key}.${errors[key]}`}
+                                    </Snippet>
+                                </a>
+                            </li>;
+                        }
                         )
                     }
                 </ul>

--- a/packages/asl-components/src/layouts/form/index.jsx
+++ b/packages/asl-components/src/layouts/form/index.jsx
@@ -12,7 +12,7 @@ const FormLayout = ({
     <div className={classnames('govuk-grid-row', className)}>
         <div className="govuk-grid-column-two-thirds">
             <OpenTaskWarning openTasks={openTasks} />
-            <ErrorSummary />
+            <ErrorSummary formatters={props.formatters} />
             {
                 children
             }


### PR DESCRIPTION
The formatters provided to a form provide a renderContext with variables to inject into mustache templates for content snippets for that field. This includes the snippets for error messages. The form's formatters should be passed to the error summary so that it can apply them when rendering error message snippets.

This fixes the defects raised against [ASL-4606](https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4606) and [ASL-4614](https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4614) where the error messages in the summary are missing the word "both" or "all" as these are variable on the role chosen and provided via the declaration's formatter's renderContext.