### PR TITLE
[ASL-4178] Set changes received from server rather than adding

### DIFF
--- a/packages/asl-projects/client/actions/projects.js
+++ b/packages/asl-projects/client/actions/projects.js
@@ -118,6 +118,15 @@ export function addChanges(changes = {}) {
   };
 }
 
+export function setChanges(changes = {}) {
+  return {
+    type: types.SET_CHANGES,
+    first: changes.first || [],
+    granted: changes.granted || [],
+    latest: changes.latest || []
+  };
+}
+
 export function updateSavedProject(project) {
   return {
     type: types.UPDATE_SAVED_PROJECT,
@@ -313,7 +322,7 @@ const syncProject = (dispatch, getState) => {
     .then(() => dispatch(updateProject(project)))
     .then(() => sendMessage(params))
     .then(json => {
-      dispatch(addChanges(json.changes));
+      dispatch(setChanges(json.changes));
       dispatch(doneSyncing());
       if (state.application.syncError) {
         dispatch(syncErrorResolved());

--- a/packages/asl-projects/client/actions/types.js
+++ b/packages/asl-projects/client/actions/types.js
@@ -25,6 +25,7 @@ export const REFRESH_COMMENTS = 'REFRESH_COMMENTS';
 
 export const ADD_CHANGE = 'ADD_CHANGE';
 export const ADD_CHANGES = 'ADD_CHANGES';
+export const SET_CHANGES = 'SET_CHANGES';
 export const LOAD_QUESTION_VERSIONS = 'LOAD_QUESTION_VERSIONS';
 export const ERROR = 'ERROR';
 

--- a/packages/asl-projects/client/pages/sections/index.js
+++ b/packages/asl-projects/client/pages/sections/index.js
@@ -83,24 +83,7 @@ class Questions extends PureComponent {
                 values={values}
                 onFieldChange={save}
               />
-              <Controls
-                onContinue={async () => {
-                  await advance();
-                  // When first loading the add additional establishment form, the page reload removes the default
-                  // initial establishment. Since the reload is for change badge synchronisation, we can safely skip
-                  // it when adding the first additional establishment to a licence.
-                  const isEstablishmentsSection = window.location.pathname.includes('/edit/establishments');
-                  const isAddingFirstAdditionalEstablishment =
-                    values['other-establishments'] === true &&
-                    (values['establishments']?.length ?? 0) === 0;
-                  if (!(isEstablishmentsSection && isAddingFirstAdditionalEstablishment)) {
-                    window.location.reload();
-                  }
-                }}
-                onExit={exit}
-                continueDisabled={this.props.isSyncing}
-                advanceLabel={this.props.isSyncing ? "Saving..." : "Continue"}
-              />
+              <Controls onContinue={advance} onExit={exit} />
             </div>
           )
         }

--- a/packages/asl-projects/client/reducers/changes.js
+++ b/packages/asl-projects/client/reducers/changes.js
@@ -34,6 +34,15 @@ const changes = (state = INITIAL_STATE, action) => {
         latest
       };
     }
+
+    case types.SET_CHANGES: {
+      return {
+        ...state,
+        granted: action.granted.reduce((arr, item) => changedItems(arr, item), []),
+        latest: action.latest.reduce((arr, item) => changedItems(arr, item), []),
+        first: action.first.reduce((arr, item) => changedItems(arr, item), [])
+      };
+    }
   }
 
   return state;


### PR DESCRIPTION
When an updated set of changes between previous versions is received in response to the background syncing of updates.

Previously this was adding new changes which means that changes that were reverted were never removed.