### PR TITLE
[ASL-4178] Fix change tracking issues

### DIFF
--- a/packages/asl-projects/client/actions/projects.js
+++ b/packages/asl-projects/client/actions/projects.js
@@ -110,20 +110,13 @@ export function addChange(change) {
   };
 }
 
-export function addChanges(changes = {}) {
-  return {
-    type: types.ADD_CHANGES,
-    granted: changes.granted || [],
-    latest: changes.latest || []
-  };
-}
-
-export function setChanges(changes = {}) {
+export function setChanges(changes = {}, version = 0) {
   return {
     type: types.SET_CHANGES,
     first: changes.first || [],
     granted: changes.granted || [],
-    latest: changes.latest || []
+    latest: changes.latest || [],
+    version
   };
 }
 
@@ -322,7 +315,7 @@ const syncProject = (dispatch, getState) => {
     .then(() => dispatch(updateProject(project)))
     .then(() => sendMessage(params))
     .then(json => {
-      dispatch(setChanges(json.changes));
+      dispatch(setChanges(json.changes, state.changes.version));
       dispatch(doneSyncing());
       if (state.application.syncError) {
         dispatch(syncErrorResolved());

--- a/packages/asl-projects/client/actions/types.js
+++ b/packages/asl-projects/client/actions/types.js
@@ -24,7 +24,6 @@ export const COMMENT_DELETED = 'COMMENT_DELETED';
 export const REFRESH_COMMENTS = 'REFRESH_COMMENTS';
 
 export const ADD_CHANGE = 'ADD_CHANGE';
-export const ADD_CHANGES = 'ADD_CHANGES';
 export const SET_CHANGES = 'SET_CHANGES';
 export const LOAD_QUESTION_VERSIONS = 'LOAD_QUESTION_VERSIONS';
 export const ERROR = 'ERROR';


### PR DESCRIPTION
- Keep an incrementing local version number to track if a server response is missing newer changes
- Explicitly remove added establishment data if other-establishments is reverted to No
- Remove obsolete addChanges redux action