### PR TITLE
[ASL-4820] Normalise deleted/restored protocols

### DIFF
--- a/packages/asl-projects/client/helpers/index.js
+++ b/packages/asl-projects/client/helpers/index.js
@@ -112,10 +112,10 @@ export const getScrollPos = (elem, offset = 0) => {
 };
 
 function mapReusableStepsToReferringSteps(project) {
-  return project.protocols.flatMap(
+  return (project.protocols ?? []).flatMap(
     (protocol) =>
-      protocol.steps
-        .filter(step => step.reusableStepId)
+      (protocol?.steps ?? [])
+        .filter(step => step?.reusableStepId)
         .map(
           step => ({
             source: `reusableSteps.${step.reusableStepId}`,

--- a/packages/asl-projects/client/helpers/steps.js
+++ b/packages/asl-projects/client/helpers/steps.js
@@ -6,8 +6,8 @@ export const hydrateSteps = (protocols, steps, reusableSteps) => {
 
   const reusableStepsInAllProtocols =
     flatMap((protocols || [])
-      .filter(protocol => !protocol.deleted), (protocol, index) => (protocol.steps || [])
-      .filter(step => !!step.reusableStepId)
+      .filter(protocol => !protocol?.deleted), (protocol, index) => (protocol.steps || [])
+      .filter(step => !!step?.reusableStepId)
       .map(step => {
         return { reusableStepId: step.reusableStepId, protocolIndex: index + 1, protocolId: protocol.id };
       })
@@ -99,7 +99,7 @@ export const reusableStepFieldKeys = (protocol) => {
     return [];
   }
   return (protocol.steps || [])
-    .filter(step => step.reusableStepId)
+    .filter(step => step?.reusableStepId)
     .map(reusableStep => `reusableSteps.${reusableStep.reusableStepId}`);
 };
 


### PR DESCRIPTION
This is the same fix as https://github.com/UKHomeOffice/aspel-workspace/pull/119 applied to protocols

Also fixes some issues when a step/protocol is null