### PR TITLE
purposed fix for set header issue.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukhomeoffice/aspel_workspace",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukhomeoffice/aspel_workspace",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "workspaces": [
         "packages/*"
       ],
@@ -23605,7 +23605,7 @@
       }
     },
     "packages/asl": {
-      "version": "2.0.5",
+      "version": "2.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23647,7 +23647,7 @@
       }
     },
     "packages/asl-attachments": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -23675,7 +23675,7 @@
     },
     "packages/asl-components": {
       "name": "@ukhomeoffice/asl-components",
-      "version": "13.9.5",
+      "version": "13.9.6",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",
@@ -23773,14 +23773,14 @@
     },
     "packages/asl-constants": {
       "name": "@ukhomeoffice/asl-constants",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.40.0"
       }
     },
     "packages/asl-data-exports": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -24060,14 +24060,14 @@
     },
     "packages/asl-dictionary": {
       "name": "@ukhomeoffice/asl-dictionary",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.27.0"
       }
     },
     "packages/asl-emailer": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "file:../asl-service",
@@ -24892,7 +24892,7 @@
       }
     },
     "packages/asl-internal-api": {
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -25201,7 +25201,7 @@
       }
     },
     "packages/asl-internal-ui": {
-      "version": "3.7.5",
+      "version": "3.7.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25471,7 +25471,7 @@
       }
     },
     "packages/asl-metrics": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@asl/projects": "file:../asl-projects",
@@ -25782,7 +25782,7 @@
       }
     },
     "packages/asl-notifications": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -26628,7 +26628,7 @@
     },
     "packages/asl-pages": {
       "name": "@asl/pages",
-      "version": "31.10.5",
+      "version": "31.10.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -27165,7 +27165,7 @@
       }
     },
     "packages/asl-permissions": {
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -28125,7 +28125,7 @@
     },
     "packages/asl-projects": {
       "name": "@asl/projects",
-      "version": "15.10.5",
+      "version": "15.10.6",
       "license": "MIT",
       "dependencies": {
         "@asl/service": "file:../asl-service",
@@ -28834,7 +28834,7 @@
       }
     },
     "packages/asl-public-api": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -29312,7 +29312,7 @@
       }
     },
     "packages/asl-resolver": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -29780,7 +29780,7 @@
     },
     "packages/asl-schema": {
       "name": "@asl/schema",
-      "version": "11.1.6",
+      "version": "11.1.7",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "file:../asl-constants",
@@ -31107,7 +31107,7 @@
       }
     },
     "packages/asl-search": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@acuris/aws-es-connection": "^2.1.0",
@@ -31455,7 +31455,7 @@
     },
     "packages/asl-service": {
       "name": "@asl/service",
-      "version": "11.0.5",
+      "version": "11.0.6",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
@@ -31791,7 +31791,7 @@
     },
     "packages/asl-taskflow": {
       "name": "@ukhomeoffice/asl-taskflow",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.18.3",
@@ -32143,7 +32143,7 @@
       }
     },
     "packages/asl-toolbox": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",
@@ -32172,7 +32172,7 @@
       }
     },
     "packages/asl-workflow": {
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@asl/schema": "file:../asl-schema",


### PR DESCRIPTION
Fix: 
https://opensearch-notprod.acp.homeoffice.gov.uk/app/discover#/doc/1d5f13b0-b435-11ed-8e3f-810010040a12/kubernetes-acp-notprod-asl-dev-000091?id=9mEZVpgBIfCCYE7iTb6x


callback() is being called:
 - inside onAllReady() (via writable.on('finish'))
 - possibly again inside onError() (when React streaming fails or chunks break)

This leads to Error: Cannot set headers after they are sent to the client
