### PR TITLE
tested with assiblity tool

### DIFF
--- a/packages/asl-components/src/markdown/index.jsx
+++ b/packages/asl-components/src/markdown/index.jsx
@@ -64,9 +64,8 @@ const ParagraphComponent = ({
         return <div {...paragraphProps} {...props}>{children}</div>;
     }
 
-    // inline mark elements should not be wrapped in a paragraph, extend
-    if (childrenArray.every(child => typeof child === 'string' || (React.isValidElement(child) && (child.type?.name === 'mark')) ))
-    {
+    // inline markdown for in-complete training page
+    if (unwrapSingleLine) {
         return <span {...paragraphProps} {...props}>{children}</span>;
     }
 


### PR DESCRIPTION
found that the previous fix was causing accessibility issues, such as wrapping <h3> and <div> elements, etc. 


