### PR TITLE
[ASL-4885] - Check that pil.id is set before querying APIs/DB

### DIFF
--- a/packages/asl-pages/pages/common/middleware/enforcement-flags.js
+++ b/packages/asl-pages/pages/common/middleware/enforcement-flags.js
@@ -5,7 +5,7 @@ module.exports = (req, res, next) => {
 
   const model = res.enforcementModel;
 
-  if (!model) {
+  if (!model?.id) {
     return next();
   }
 

--- a/packages/asl-pages/pages/common/routers/related-tasks.js
+++ b/packages/asl-pages/pages/common/routers/related-tasks.js
@@ -11,6 +11,10 @@ module.exports = getQuery => {
     let { model, modelId } = query;
     model = model === 'profile-touched' ? 'profile' : model;
 
+    if (!modelId) {
+      return false;
+    }
+
     const params = {
       id: modelId,
       establishment: model === 'establishment' ? modelId : query.establishmentId

--- a/packages/asl-public-api/.eslintrc
+++ b/packages/asl-public-api/.eslintrc
@@ -1,6 +1,9 @@
 extends:
   - "@ukhomeoffice/asl"
 
+parserOptions:
+  ecmaVersion: 2020
+
 plugins:
   - undocumented-env
 

--- a/packages/asl-public-api/lib/middleware/fetch-reminders.js
+++ b/packages/asl-public-api/lib/middleware/fetch-reminders.js
@@ -94,7 +94,7 @@ module.exports = modelType => async (req, res, next) => {
       break;
 
     case 'pil':
-      if (!req.pil || !isAsruOrLicenceHolder(req.user.profile, req.pil)) {
+      if (!req.pil?.id || !isAsruOrLicenceHolder(req.user.profile, req.pil)) {
         return next();
       }
 


### PR DESCRIPTION

Various API calls/database queries assume pil.id is always set. This is not the case when the user only has training PILs and a stub pil response has been returned by the profile API. This checks for the presence of the id in places where it was otherwise causing that user's PIL page to throw an error.