### PR TITLE
[ASL-4843] Bugfix - consistent source for feature flag constants

### DIFF
--- a/packages/asl-constants/constants/feature-flags.js
+++ b/packages/asl-constants/constants/feature-flags.js
@@ -1,7 +1,0 @@
-const FEATURE_FLAG_NAMED_PERSON_MVP = 'feature-named-person-mvp';
-const FEATURE_FLAG_CAT_E = 'feature-cat-e';
-
-module.exports = {
-  FEATURE_FLAG_NAMED_PERSON_MVP,
-  FEATURE_FLAG_CAT_E,
-};

--- a/packages/asl-constants/index.js
+++ b/packages/asl-constants/index.js
@@ -16,7 +16,6 @@ const species = require('./constants/species');
 const projectSpecies = require('./constants/project-species');
 const fees = require('./constants/fees');
 const trainingCoursePurpose = require('./constants/training-course-purpose');
-const featureFlags = require('./constants/feature-flags');
 const versions = require('./constants/versions');
 
 module.exports = {
@@ -38,6 +37,5 @@ module.exports = {
   species,
   fees,
   trainingCoursePurpose,
-  featureFlags,
   versions,
 };

--- a/packages/asl-pages/pages/course/index.js
+++ b/packages/asl-pages/pages/course/index.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { FEATURE_FLAG_CAT_E } = require('@ukhomeoffice/asl-constants/constants/feature-flags');
+const { FEATURE_FLAG_CAT_E } = require('@asl/service/ui/feature-flag');
 const routes = require('./routes');
 
 module.exports = settings => {

--- a/packages/asl-pages/pages/course/index.js
+++ b/packages/asl-pages/pages/course/index.js
@@ -8,7 +8,7 @@ module.exports = settings => {
   app.use(
     (req, res, next) => {
       if (!req.hasFeatureFlag(FEATURE_FLAG_CAT_E)) {
-        return res.redirect(req.buildRoute('pil.unscoped.courses.list'));
+        return res.redirect(req.buildRoute('pils.courses.list'));
       }
 
       if (!req.establishment?.isTrainingEstablishment) {

--- a/packages/asl-pages/pages/profile/read/views/roles-at-establishment.jsx
+++ b/packages/asl-pages/pages/profile/read/views/roles-at-establishment.jsx
@@ -2,11 +2,10 @@ import React, { Fragment } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import { Link, Snippet } from '@ukhomeoffice/asl-components';
 import { defineValue } from '../../../common/formatters';
-import { useFeatureFlag } from '@asl/service/ui/feature-flag';
-const { featureFlags } = require('@ukhomeoffice/asl-constants');
+import { useFeatureFlag, FEATURE_FLAG_NAMED_PERSON_MVP } from '@asl/service/ui/feature-flag';
 
 function RolesAtEstablishment({ establishment, estRoles, rcvsNumber, allowedActions, profile }) {
-  const namedPersonFeatureFlag = useFeatureFlag(featureFlags.FEATURE_FLAG_NAMED_PERSON_MVP);
+  const namedPersonFeatureFlag = useFeatureFlag(FEATURE_FLAG_NAMED_PERSON_MVP);
   const addRoleLink = namedPersonFeatureFlag ? 'role.namedPersonMvp.beforeYouApply' : 'role.create';
 
   return (

--- a/packages/asl-pages/pages/role/named-person-mvp/index.js
+++ b/packages/asl-pages/pages/role/named-person-mvp/index.js
@@ -1,12 +1,12 @@
 const { Router } = require('express');
 const routes = require('./routes');
-const { FEATURE_NAMED_PERSON_MVP } = require('@asl/service/ui/feature-flag');
+const { FEATURE_FLAG_NAMED_PERSON_MVP } = require('@asl/service/ui/feature-flag');
 
 module.exports = () => {
   const app = Router();
 
   app.use((req, res, next) => {
-    if (!req.hasFeatureFlag(FEATURE_NAMED_PERSON_MVP)) {
+    if (!req.hasFeatureFlag(FEATURE_FLAG_NAMED_PERSON_MVP)) {
       return res.redirect(req.buildRoute('role.create'));
     }
 

--- a/packages/asl-pages/pages/success/index.js
+++ b/packages/asl-pages/pages/success/index.js
@@ -3,7 +3,7 @@ const { merge, get, upperFirst } = require('lodash');
 const { Router } = require('express');
 const { NotFoundError } = require('@asl/service/errors');
 const successMessages = require('./content');
-const { FEATURE_NAMED_PERSON_MVP } = require('@asl/service/ui/feature-flag');
+const { FEATURE_FLAG_NAMED_PERSON_MVP } = require('@asl/service/ui/feature-flag');
 const { versions } = require('@ukhomeoffice/asl-constants');
 
 const headerContent = (title, subtitle) => {
@@ -212,11 +212,11 @@ module.exports = () => {
     const success = merge(
       {},
       successMessages.default,
-      req.hasFeatureFlag(FEATURE_NAMED_PERSON_MVP)
+      req.hasFeatureFlag(FEATURE_FLAG_NAMED_PERSON_MVP)
         ? successMessages.default.namedPerson
         : {},
       get(successMessages, successType),
-      req.hasFeatureFlag(FEATURE_NAMED_PERSON_MVP)
+      req.hasFeatureFlag(FEATURE_FLAG_NAMED_PERSON_MVP)
         ? get(successMessages, `${successType}.namedPerson`)
         : {},
       getTaskContent(req.task)

--- a/packages/asl-service/ui/feature-flag.js
+++ b/packages/asl-service/ui/feature-flag.js
@@ -1,7 +1,11 @@
 const { useSelector } = require('react-redux');
 const { set } = require('lodash');
-const { featureFlags } = require('@ukhomeoffice/asl-constants');
 const { useCallback } = require('react');
+
+const flags = {
+  FEATURE_FLAG_NAMED_PERSON_MVP: 'feature-named-person-mvp',
+  FEATURE_FLAG_CAT_E: 'feature-cat-e'
+};
 
 const useFeatureFlags = () => {
   const roles = useSelector(state => state.static.keycloakRoles ?? []);
@@ -19,5 +23,5 @@ module.exports = {
     return useFeatureFlags()(flag);
   },
   useFeatureFlags,
-  ...featureFlags
+  ...flags
 };


### PR DESCRIPTION
When the feature flag constants were copied to asl-constants they were not given the same prefix, so when the constants were used to replace the feature flag list that was duplicated in asl-service, the names no longer matched.