### PR TITLE
[ASL-4655] Return emailer promise to prevent script exiting early

### DIFF
--- a/packages/asl-notifications/jobs/training-due-reminder.js
+++ b/packages/asl-notifications/jobs/training-due-reminder.js
@@ -37,7 +37,7 @@ module.exports = async ({ schema, logger, publicUrl }) => {
 
   logger.debug(`Found ${rolesWithTrainingOutstanding.length} roles with training due reminders to send`);
 
-  return Promise.all(rolesWithTrainingOutstanding.map(role => {
+  return Promise.all(rolesWithTrainingOutstanding.map(role =>
     emailer({
       event: 'direct-notification',
       data: {
@@ -55,6 +55,5 @@ module.exports = async ({ schema, logger, publicUrl }) => {
           completeDate: role.trainingDelayDetails.completeDate
         }
       }
-    });
-  }));
+    })));
 };


### PR DESCRIPTION
Because the promise returned by `emailer` is not propagated to `Promise.all`, `Promise.all` completes early and the `exit(0)` on line 44 of run-job is triggered, terminating the process before the async functions complete building the notifications.